### PR TITLE
Improve get_flow_run output for LLM consumption

### DIFF
--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -123,17 +123,26 @@ async def get_flow_run(
             description="Whether to include execution logs",
         ),
     ] = False,
+    log_limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of log entries to return",
+            ge=1,
+            le=1000,
+        ),
+    ] = 100,
 ) -> FlowRunResult:
     """Get detailed information about a flow run.
 
     Retrieves comprehensive flow run details including state, parameters,
-    timestamps, and optionally the execution logs.
+    timestamps, and optionally the execution logs with readable log levels.
 
     Examples:
         - Get flow run details: get_flow_run("068adce4-aeec-7e9b-8000-97b7feeb70fa")
         - With logs: get_flow_run("068adce4-aeec-7e9b-8000-97b7feeb70fa", include_logs=True)
+        - With limited logs: get_flow_run("068adce4-aeec-7e9b-8000-97b7feeb70fa", include_logs=True, log_limit=50)
     """
-    return await _prefect_client.get_flow_run(flow_run_id, include_logs)
+    return await _prefect_client.get_flow_run(flow_run_id, include_logs, log_limit)
 
 
 @mcp.tool

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -134,8 +134,17 @@ class LogEntry(TypedDict):
 
     timestamp: str | None
     level: int | None
+    level_name: str | None  # Human-readable log level (INFO, ERROR, etc)
     message: str
     name: str | None
+
+
+class LogSummary(TypedDict):
+    """Summary of log retrieval."""
+
+    returned_logs: int
+    truncated: bool
+    limit: int
 
 
 class FlowRunResult(TypedDict, total=False):
@@ -144,5 +153,6 @@ class FlowRunResult(TypedDict, total=False):
     success: bool
     flow_run: FlowRunDetail | None
     logs: list[LogEntry]  # Only present if include_logs=True
+    log_summary: LogSummary | None  # Only present if logs were truncated
     error: str | None
     log_error: str | None  # Only present if log fetch failed


### PR DESCRIPTION
## Summary

Implements the improvements identified in issue #7 to make the `get_flow_run` tool output more consumable for LLMs and humans.

## Changes

### 1. Convert log levels to readable names
- Added mapping from numeric levels (10, 20, 30, 40, 50) to strings (DEBUG, INFO, WARNING, ERROR, CRITICAL)
- Each log entry now includes both `level` (numeric) and `level_name` (string)

### 2. Extract flow name from labels  
- **No extra API call needed!** 
- Discovered that flow name is available in `flow_run.labels["prefect.flow.name"]`
- Previously was hardcoded to `None` with a comment about needing extra fetch

### 3. Add log limiting with truncation info
- Added `log_limit` parameter (default 100, max 1000)
- When logs exceed limit, returns truncated list with `log_summary` info
- Summary includes: `returned_logs`, `truncated`, and `limit`

## Example Output

```json
{
  "flow_run": {
    "name": "dazzling-jackal",
    "flow_name": "data-processor",  // Now populated from labels!
    ...
  },
  "logs": [
    {
      "level": 20,
      "level_name": "INFO",  // Human-readable!
      "message": "Beginning flow run...",
      ...
    }
  ],
  "log_summary": {  // Only when truncated
    "returned_logs": 100,
    "truncated": true,
    "limit": 100
  }
}
```

## Testing

Tested with real flow runs to verify:
- Flow name is correctly extracted from labels
- Log levels display as readable names
- Log truncation works correctly with summary info
- All existing tests pass

Closes #7

🤖 Generated with Claude Code