### PR TITLE
Convert inspection tools to resource templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@ this is an MCP server for interacting with a Prefect API (OSS or Cloud)
 
 
 ## rules for contributors
+- look to the @justfile for dev workflow stuff
 - never use `from typing import Dict, List, Optional` etc, use built-ins `dict`, `list`, `T | None` etc
 - put prefect API glue code in the `_prefect_client` directory
 - keep @src/prefect_mcp_server/server.py concise and focused on how we want to enable clients

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,14 +17,23 @@ async def test_server_has_expected_capabilities(prefect_mcp_server: FastMCP) -> 
         assert "prefect://dashboard" in resource_uris
         assert len(resources) == 2
 
+        # Check resource templates separately
+        templates = await client.list_resource_templates()
+        template_uris = [str(t.uriTemplate) for t in templates]
+        assert "prefect://flow-runs/{flow_run_id}" in template_uris
+        assert "prefect://deployments/{deployment_id}" in template_uris
+        assert "prefect://task-runs/{task_run_id}" in template_uris
+        assert len(templates) == 3
+
         tools = await client.list_tools()
         tool_names = [t.name for t in tools]
         assert "run_deployment_by_name" in tool_names
         assert "read_events" in tool_names
-        assert "get_flow_run" in tool_names
-        assert "get_deployment" in tool_names
-        assert "get_task_run" in tool_names
-        assert len(tools) == 5
+        # These are now resource templates, not tools
+        assert "get_flow_run" not in tool_names
+        assert "get_deployment" not in tool_names
+        assert "get_task_run" not in tool_names
+        assert len(tools) == 2
 
 
 async def test_list_deployments_with_test_data(


### PR DESCRIPTION
This PR converts three inspection tools to resource templates, following FastMCP best practices for separating read-only data access (resources) from state-modifying actions (tools).

## Changes

**Converted to Resource Templates:**
- `get_flow_run` → `prefect://flow-runs/{flow_run_id}`
- `get_deployment` → `prefect://deployments/{deployment_id}` 
- `get_task_run` → `prefect://task-runs/{task_run_id}`

**Remained as Tools:**
- `read_events` - Complex filtering that doesn't map well to URI patterns
- `run_deployment_by_name` - State-modifying action (creates flow runs)

## Benefits

Resource templates provide a more RESTful API design that aligns better with MCP principles:
- Clean separation between data access (resources) and actions (tools)
- URI-based parameterization follows REST conventions
- Support for query parameters (e.g., `?include_logs=true&log_limit=50`)
- Better discoverability through the MCP resource template system

## Usage Examples

```
# Before (tool calls)
get_flow_run("123", include_logs=True, log_limit=50)

# After (resource access)
prefect://flow-runs/123?include_logs=true&log_limit=50
```

All tests updated and passing. The underlying client functions remain unchanged, only the MCP server interface has been improved.

🤖 Generated with [Claude Code](https://claude.ai/code)