### PR TITLE
Simplify debug_flow_run prompt interface

### DIFF
--- a/src/prefect_mcp_server/_prompts/debug.py
+++ b/src/prefect_mcp_server/_prompts/debug.py
@@ -3,81 +3,72 @@
 
 def create_debug_prompt(
     flow_run_id: str | None = None,
-    deployment_name: str | None = None,
-    work_pool_name: str | None = None,
 ) -> str:
     """Create a debugging prompt for troubleshooting Prefect flow runs.
 
-    Based on the provided context, generates a structured prompt to guide
-    debugging of flow runs, deployments, and infrastructure issues.
+    If a flow_run_id is provided, generates specific debugging steps for that run.
+    Otherwise, provides general flow run debugging guidance.
     """
-    prompt_parts = ["To debug this Prefect flow run issue, follow these steps:", ""]
-    step_num = 1
-
     if flow_run_id:
-        prompt_parts.extend(
-            [
-                f"{step_num}. Flow Run Analysis for ID {flow_run_id}:",
-                "   - Check the current state and any error messages",
-                "   - Review task failures in the logs",
-                "   - Look for state transition events",
-                "   - Examine the flow run parameters and context",
-                "",
-            ]
-        )
-        step_num += 1
-
-    if deployment_name:
-        prompt_parts.extend(
-            [
-                f"{step_num}. Deployment Configuration for '{deployment_name}':",
-                "   - Verify work pool assignment and availability",
-                "   - Check infrastructure overrides and settings",
-                "   - Review environment variables and secrets",
-                "   - Examine the deployment schedule if applicable",
-                "",
-            ]
-        )
-        step_num += 1
-
-    if work_pool_name:
-        prompt_parts.extend(
-            [
-                f"{step_num}. Work Pool Status for '{work_pool_name}':",
-                "   - Verify the work pool is online with available workers",
-                "   - Check for queue concurrency limits",
-                "   - Review worker health and recent activity",
-                "   - Examine infrastructure configuration",
-                "",
-            ]
-        )
-
-    if not any([flow_run_id, deployment_name, work_pool_name]):
+        # Specific flow run debugging
+        prompt_parts = [
+            f"To debug flow run {flow_run_id}, follow these steps:",
+            "",
+            "1. Get Flow Run Details:",
+            f"   - Fetch the flow run: prefect://flow-runs/{flow_run_id}",
+            "   - Check the state_type, state_name, and state_message",
+            "   - Note the deployment_id, work_queue_name, and infrastructure_pid",
+            "",
+            "2. Examine Logs:",
+            f"   - Get logs: prefect://flow-runs/{flow_run_id}/logs",
+            "   - Look for ERROR or CRITICAL level messages",
+            "   - Check the last few log entries before failure",
+            "",
+            "3. Check Related Resources:",
+            "   - If deployment_id exists, fetch: prefect://deployments/{{deployment_id}}",
+            "   - Review deployment parameters vs actual flow run parameters",
+            "   - Check work_pool_name and work_queue_name configuration",
+            "",
+            "4. Review Events:",
+            "   - Use read_events with event_type_prefix='prefect.flow-run'",
+            "   - Look for state transitions and error events",
+            "   - Check timing between events for delays or timeouts",
+            "",
+            "5. Common Issues to Check:",
+            "   - Parameter mismatches between deployment and run",
+            "   - Work pool offline or no available workers",
+            "   - Infrastructure timeout or resource limits exceeded",
+            "   - Import errors or missing dependencies",
+            "   - Environment variable or secrets configuration",
+        ]
+    else:
         # General debugging guidance
         prompt_parts = [
             "To debug Prefect flow runs, examine these key areas:",
             "",
-            "1. Flow Run State:",
-            "   - Use `read_events` with event_type_prefix='prefect.flow-run' to see recent flow activity",
+            "1. Recent Flow Activity:",
+            "   - Use read_events(event_type_prefix='prefect.flow-run') to see recent activity",
             "   - Look for FAILED or CRASHED states",
             "   - Check state transition patterns for anomalies",
             "",
-            "2. Deployment Health:",
-            "   - List deployments to verify they exist and are configured",
-            "   - Check if schedules are active",
-            "   - Review deployment tags and parameters",
-            "",
-            "3. System Overview:",
-            "   - Check the dashboard for current running/pending/failed counts",
+            "2. System Overview:",
+            "   - Check prefect://dashboard for current running/pending/failed counts",
             "   - Look for patterns in recent failures",
-            "   - Verify work pools are available",
+            "   - Verify work pools are available and healthy",
             "",
-            "Common issues to check:",
-            "- Missing or misconfigured work pools",
-            "- Environment variable issues",
-            "- Infrastructure timeout or resource limits",
-            "- Parameter validation errors",
-            "- Dependency or import failures",
+            "3. Deployment Health:",
+            "   - List deployments with prefect://deployments/list",
+            "   - Check if schedules are active",
+            "   - Review deployment parameters and configuration",
+            "",
+            "4. Common Issues to Check:",
+            "   - Missing or misconfigured work pools",
+            "   - Environment variable or secrets issues",
+            "   - Infrastructure timeout or resource limits",
+            "   - Parameter validation errors",
+            "   - Import errors or missing dependencies",
+            "",
+            "To debug a specific flow run, provide its UUID to get targeted debugging steps.",
         ]
 
     return "\n".join(prompt_parts)

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -26,21 +26,18 @@ mcp = FastMCP("Prefect MCP Server")
 @mcp.prompt
 def debug_flow_run(
     flow_run_id: str | None = None,
-    deployment_name: str | None = None,
-    work_pool_name: str | None = None,
 ) -> str:
     """Generate debugging guidance for troubleshooting Prefect flow runs.
 
-    Provides structured steps for investigating flow run failures,
-    deployment issues, and infrastructure problems.
+    Provides structured steps for investigating a specific flow run failure
+    or general debugging guidance if no flow run ID is provided.
+
+    Args:
+        flow_run_id: UUID of a specific flow run to debug (optional)
     """
     from prefect_mcp_server._prompts import create_debug_prompt
 
-    return create_debug_prompt(
-        flow_run_id=flow_run_id,
-        deployment_name=deployment_name,
-        work_pool_name=work_pool_name,
-    )
+    return create_debug_prompt(flow_run_id=flow_run_id)
 
 
 # Resources - read-only operations

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -22,10 +22,11 @@ async def test_debug_flow_run_prompt_no_params():
         content = result.messages[0].content.text
 
         # Check for key sections
-        assert "Flow Run State:" in content
-        assert "Deployment Health:" in content
+        assert "Recent Flow Activity:" in content
         assert "System Overview:" in content
-        assert "Common issues to check:" in content
+        assert "Deployment Health:" in content
+        assert "Common Issues to Check:" in content
+        assert "To debug a specific flow run, provide its UUID" in content
 
 
 async def test_debug_flow_run_prompt_with_flow_run_id():
@@ -34,49 +35,7 @@ async def test_debug_flow_run_prompt_with_flow_run_id():
         result = await client.get_prompt("debug_flow_run", {"flow_run_id": "test-123"})
 
         content = result.messages[0].content.text
-        assert "Flow Run Analysis for ID test-123" in content
-        assert "Check the current state and any error messages" in content
-
-
-async def test_debug_flow_run_prompt_with_deployment():
-    """Test prompt with deployment_name parameter."""
-    async with Client(mcp) as client:
-        result = await client.get_prompt(
-            "debug_flow_run", {"deployment_name": "my-deployment"}
-        )
-
-        content = result.messages[0].content.text
-        assert "1. Deployment Configuration for 'my-deployment'" in content
-        assert "Verify work pool assignment" in content
-
-
-async def test_debug_flow_run_prompt_with_work_pool():
-    """Test prompt with work_pool_name parameter."""
-    async with Client(mcp) as client:
-        result = await client.get_prompt(
-            "debug_flow_run", {"work_pool_name": "test-pool"}
-        )
-
-        content = result.messages[0].content.text
-        assert "1. Work Pool Status for 'test-pool'" in content
-        assert "Verify the work pool is online" in content
-
-
-async def test_debug_flow_run_prompt_all_params():
-    """Test prompt with all parameters."""
-    async with Client(mcp) as client:
-        result = await client.get_prompt(
-            "debug_flow_run",
-            {
-                "flow_run_id": "abc-123",
-                "deployment_name": "prod-flow",
-                "work_pool_name": "k8s-pool",
-            },
-        )
-
-        content = result.messages[0].content.text
-
-        # Check all three sections are present with correct numbering
-        assert "1. Flow Run Analysis for ID abc-123" in content
-        assert "2. Deployment Configuration for 'prod-flow'" in content
-        assert "3. Work Pool Status for 'k8s-pool'" in content
+        assert "To debug flow run test-123" in content
+        assert "Get Flow Run Details:" in content
+        assert "prefect://flow-runs/test-123" in content
+        assert "Examine Logs:" in content


### PR DESCRIPTION
## Summary

Simplifies the `debug_flow_run` prompt to focus on what it's actually for - debugging flow runs. Removes confusing parameters that suggested deployment and work pool debugging were separate workflows.

## Problem

The previous interface accepted three parameters:
- `flow_run_id` - makes sense, you're debugging a specific flow run
- `deployment_name` - confusing, suggests you debug deployments independently  
- `work_pool_name` - confusing, suggests you debug work pools independently

In practice, when debugging you:
1. Start with a flow run that failed
2. From that flow run, you might check its deployment configuration
3. From that flow run, you might check its work pool status

The deployment and work pool are properties OF the flow run, not separate debugging entry points.

## Solution

The prompt now has a single, optional parameter:
- `flow_run_id` - If provided, gives specific debugging steps for that flow run
- If not provided, gives general debugging guidance

## Example Usage

### With a specific flow run:
```python
prompt = debug_flow_run(flow_run_id="abc-123-def-456")
# Returns specific steps like:
# 1. Get Flow Run Details:
#    - Fetch the flow run: prefect://flow-runs/abc-123-def-456
#    - Check the state_type, state_name, and state_message
# 2. Examine Logs:
#    - Get logs: prefect://flow-runs/abc-123-def-456/logs
# ... etc
```

### Without a flow run ID:
```python
prompt = debug_flow_run()
# Returns general guidance for debugging any flow run
```

## Benefits

1. **Clearer mental model** - You debug flow runs, not deployments or work pools in isolation
2. **Better integration** - The prompt now references MCP resources directly (e.g., `prefect://flow-runs/{id}`)
3. **Simpler API** - One optional parameter instead of three confusing ones
4. **More actionable** - When given a flow run ID, provides exact resources to fetch

## Testing

- Updated tests to verify the new interface
- All tests pass
- Prompt provides useful debugging steps in both modes (specific and general)

🤖 Generated with [Claude Code](https://claude.ai/code)