### PR TITLE
Add development warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # prefect-mcp-server
 
+> [!WARNING]
+> **This project is under active development and may change drastically at any time.**
+> 
+> This is an experimental MCP server for Prefect. APIs, features, and behaviors are subject to change without notice. We encourage you to try it out, provide feedback, and contribute! Please [create issues](https://github.com/PrefectHQ/prefect-mcp-server/issues) or [open PRs](https://github.com/PrefectHQ/prefect-mcp-server/pulls) with your ideas and suggestions.
+
 a [`fastmcp`](https://github.com/jlowin/fastmcp) server for interacting with [`prefect`](https://github.com/prefecthq/prefect) resources.
 
 ## quick start


### PR DESCRIPTION
## Summary
Adds a prominent GitHub warning admonition to the README to clarify the experimental nature of this project.

## Changes
- Added a `[!WARNING]` admonition at the top of the README indicating the project is under active development
- Clarified that APIs and features may change drastically
- Encouraged community participation through issues and PRs

## Context
As discussed in Slack, this warning helps set expectations as we make the repo public while still being in early development.

🤖 Generated with Claude Code