### PR TITLE
fix publish workflow permissions to allow checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # For PyPI's trusted publishing
+      contents: read # To checkout the code
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
when explicitly setting permissions, all defaults are overridden. the workflow had `id-token: write` for trusted publishing but was missing `contents: read`, which caused checkout to fail with "repository not found" when run from a private/internal repo.

fixes the issue seen in https://github.com/PrefectHQ/prefect-mcp-server/actions/runs/18025579298

🤖 Generated with [Claude Code](https://claude.com/claude-code)