### PR TITLE
replace git dependency with prefect>=3.4.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Prefect Technologies", email = "help@prefect.io" }]
 requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=2.12.3",
-    "prefect@git+https://github.com/prefecthq/prefect.git",
+    "prefect>=3.4.22",
 ]
 
 
@@ -40,9 +40,6 @@ source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prefect_mcp_server"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
PyPI doesn't allow direct git dependencies. replaced the git reference with a version constraint for the latest stable prefect release.

fixes the publish workflow failure:
```
Can't have direct dependency: prefect@ git+https://github.com/prefecthq/prefect.git
```

also removed the now-unnecessary `allow-direct-references` hatch metadata config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)