### PR TITLE
revert to original docs MCP server URL

### DIFF
--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -40,7 +40,7 @@ mcp = FastMCP("Prefect MCP Server")
 
 # Mount the Prefect docs MCP server to expose its tools
 docs_proxy = FastMCP.as_proxy(
-    ProxyClient("https://prefect-docs-mcp.fastmcp.app/mcp"),
+    ProxyClient("https://docs.prefect.io/mcp"),
     name="Prefect Documentation Search",
 )
 mcp.mount(docs_proxy, prefix="docs")

--- a/tests/test_docs_proxy.py
+++ b/tests/test_docs_proxy.py
@@ -13,13 +13,13 @@ async def test_docs_proxy_tools_available(prefect_mcp_server: FastMCP) -> None:
         # Check that the docs SearchPrefect tool is available (prefixed with docs_)
         docs_tools = [name for name in tool_names if name.startswith("docs_")]
         assert len(docs_tools) >= 1
-        assert "docs_search_prefect" in tool_names
+        assert "docs_SearchPrefect" in tool_names
 
         # Verify the docs tool has expected properties
         docs_search_tool = next(
-            (t for t in tools if t.name == "docs_search_prefect"), None
+            (t for t in tools if t.name == "docs_SearchPrefect"), None
         )
         assert docs_search_tool is not None
         assert docs_search_tool.description is not None
-        assert "Search the Prefect knowledgebase" in docs_search_tool.description
+        assert "Prefect knowledge base" in docs_search_tool.description
         assert "search" in docs_search_tool.description.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -2369,8 +2369,8 @@ wheels = [
 
 [[package]]
 name = "prefect"
-version = "3.4.21.dev3+2.g60e4b345f"
-source = { git = "https://github.com/prefecthq/prefect.git#60e4b345fff998804dd28127c6d561a8b905dfb5" }
+version = "3.4.22"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
@@ -2427,6 +2427,10 @@ dependencies = [
     { name = "websockets" },
     { name = "whenever", marker = "python_full_version >= '3.13'" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/ed/faf33ab9f344992ca7df351fb16c1e5d9634ecb6280fa65cc708bcdd647a/prefect-3.4.22.tar.gz", hash = "sha256:4b46a793e9907a4c8539b04bb2fdbc609c9810f690d7673a3bc8d0c9aebdfc84", size = 5617829, upload-time = "2025-10-03T18:30:57.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dc/424fcdb9605bc2100902ac634daa607dfd6752c203e134883de8a831c72b/prefect-3.4.22-py3-none-any.whl", hash = "sha256:41743e2817195e1ef8fdef2e65c4b16da1308cf8f5dd1a85e679c8cbe7186710", size = 6138167, upload-time = "2025-10-03T18:30:54.844Z" },
+]
 
 [[package]]
 name = "prefect-mcp"
@@ -2460,7 +2464,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.12.3" },
     { name = "logfire", marker = "extra == 'logfire'" },
-    { name = "prefect", git = "https://github.com/prefecthq/prefect.git" },
+    { name = "prefect", specifier = ">=3.4.22" },
 ]
 provides-extras = ["logfire"]
 


### PR DESCRIPTION
## Summary
- reverts docs proxy to original https://docs.prefect.io/mcp endpoint
- updates tests to match original server's tool naming (docs_SearchPrefect) and description text

## Test plan
- [x] unit tests pass
- [x] verified tool naming convention matches original server

🤖 Generated with [Claude Code](https://claude.com/claude-code)