### PR TITLE
Use good docs MCP for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Root conftest for setting environment variables before any imports."""
+
+import os
+
+
+def pytest_configure(config):
+    """Set test environment variables before any test modules are imported."""
+    # Use good docs MCP for tests (unless already set)
+    if os.getenv("PREFECT_DOCS_MCP_URL") is None:
+        os.environ["PREFECT_DOCS_MCP_URL"] = "https://prefect-docs-mcp.fastmcp.app/mcp"


### PR DESCRIPTION
## summary
sets `PREFECT_DOCS_MCP_URL` to the good FastMCP Cloud instance for tests while keeping the default in settings pointing to the bad one

## changes
- sets env var in `tests/conftest.py` before importing server
- uses `https://prefect-docs-mcp.fastmcp.app/mcp` for tests (same as evals)
- keeps default in `settings.py` as `https://docs.prefect.io/mcp` for production

## why
- the bad docs MCP (`docs.prefect.io/mcp`) returns 500 errors and causes test timeouts
- evals already use the good one (PR #81)
- tests should use the same reliable instance as evals
- production default stays the same until we're ready to switch

## test plan
- [x] `test_docs_proxy.py` passes without 500 errors
- [x] tests complete much faster without timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>