### PR TITLE
Add `logfire` as dependency for docs MCP server

### DIFF
--- a/src/docs_mcp_server/pyproject.toml
+++ b/src/docs_mcp_server/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=2.12.3",
+    "logfire>=4.9.0",
     "openai>=1.109.1",
     "turbopuffer>=1.3.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -835,6 +835,7 @@ version = "0.1.0"
 source = { virtual = "src/docs_mcp_server" }
 dependencies = [
     { name = "fastmcp" },
+    { name = "logfire" },
     { name = "openai" },
     { name = "turbopuffer" },
 ]
@@ -842,6 +843,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.12.3" },
+    { name = "logfire", specifier = ">=4.9.0" },
     { name = "openai", specifier = ">=1.109.1" },
     { name = "turbopuffer", specifier = ">=1.3.1" },
 ]


### PR DESCRIPTION
The FastMCP build failed because we explicitly depend on `logfire` in the docs MCP server.
