### PR TITLE
add eval for diagnosing concurrency lease renewal failures

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -58,6 +58,7 @@ Provider defaults:
 | **test_create_reactive_automation** | verifies agent can create reactive automations | ✅ implemented | [#47](https://github.com/PrefectHQ/prefect-mcp-server/pull/47) |
 | **test_trigger_deployment_run** | verifies agent can trigger deployment runs with custom parameters | ✅ implemented | - |
 | **test_debug_automation_not_firing** | verifies agent can debug why an automation didn't fire due to threshold mismatch | ✅ implemented | [#62](https://github.com/PrefectHQ/prefect-mcp-server/issues/62) |
+| **test_lease_renewal_crash** | verifies agent can diagnose flow runs that crashed due to concurrency lease renewal failure | ✅ implemented | [#97](https://github.com/PrefectHQ/prefect-mcp-server/issues/97) |
 | **rate_limits/test_cloud_direct** | verifies agent can diagnose rate limiting when user asks about 429 errors (Cloud) | ✅ implemented | [#46](https://github.com/PrefectHQ/prefect-mcp-server/issues/46) |
 | **rate_limits/test_cloud_no_throttling** | verifies agent correctly rules out rate limiting when no throttling occurred (Cloud) | ✅ implemented | [#46](https://github.com/PrefectHQ/prefect-mcp-server/issues/46) |
 | **rate_limits/test_cloud_correlate_logs** | verifies agent can correlate 429 warnings in flow logs with rate limit data (Cloud) | ✅ implemented | [#46](https://github.com/PrefectHQ/prefect-mcp-server/issues/46) |

--- a/evals/test_lease_renewal_crash.py
+++ b/evals/test_lease_renewal_crash.py
@@ -25,6 +25,7 @@ import pytest
 from prefect import flow
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import GlobalConcurrencyLimitCreate
+from prefect.client.schemas.filters import FlowFilter, FlowFilterName
 from prefect.client.schemas.objects import FlowRun
 from prefect.concurrency.sync import concurrency
 from pydantic_ai import Agent
@@ -45,6 +46,7 @@ async def crashed_flow_run(prefect_client: PrefectClient) -> FlowRun:
     cancel scope, and the resulting CRASHED state - runs for real.
     """
     limit_name = f"db-connection-pool-{uuid4().hex[:8]}"
+    flow_name = f"db-sync-job-{uuid4().hex[:8]}"
     await prefect_client.create_global_concurrency_limit(
         concurrency_limit=GlobalConcurrencyLimitCreate(name=limit_name, limit=1)
     )
@@ -54,7 +56,7 @@ async def crashed_flow_run(prefect_client: PrefectClient) -> FlowRun:
     ) -> None:
         raise httpx.ConnectError("Simulated network failure during lease renewal")
 
-    @flow(name=f"db-sync-job-{uuid4().hex[:8]}")
+    @flow(name=flow_name)
     def db_sync_job() -> str:
         # strict=True -> raise_on_lease_renewal_failure=True, so a real renewal
         # failure cancels the cancel scope and crashes the run.
@@ -78,8 +80,12 @@ async def crashed_flow_run(prefect_client: PrefectClient) -> FlowRun:
             # CancelledError from the cancel scope is a BaseException
             pass
 
-    runs = await prefect_client.read_flow_runs()
-    assert runs, "expected a flow run to have been recorded"
+    # the conftest's prefect_test_harness is session-scoped, so other tests'
+    # flow runs share the same db. filter by our unique flow name.
+    runs = await prefect_client.read_flow_runs(
+        flow_filter=FlowFilter(name=FlowFilterName(any_=[flow_name])),
+    )
+    assert runs, f"expected a flow run for {flow_name!r} to have been recorded"
     return runs[0]
 
 

--- a/evals/test_lease_renewal_crash.py
+++ b/evals/test_lease_renewal_crash.py
@@ -1,0 +1,108 @@
+"""Eval for diagnosing flow runs that crash due to concurrency lease renewal failure.
+
+Based on real user issues:
+- https://github.com/PrefectHQ/prefect/issues/19068
+- https://github.com/PrefectHQ/prefect/issues/18839
+
+The scenario mirrors Prefect's own integration tests in
+prefect/integration-tests/test_concurrency_leases.py: a flow holds a concurrency
+slot, the underlying `renew_concurrency_lease` API call starts failing, and
+Prefect's real renewal loop -> retry logic -> crash handler runs end-to-end,
+terminating the flow run.
+
+We only mock the HTTP boundary (the client method that talks to the API). The
+retry policy, error logging through the run logger, and cancel-scope-driven
+crash all execute for real, so an agent diagnosing the crash sees the same
+state and log message it would in production.
+"""
+
+from collections.abc import Awaitable, Callable
+from unittest import mock
+from uuid import uuid4
+
+import httpx
+import pytest
+from prefect import flow
+from prefect.client.orchestration import PrefectClient, SyncPrefectClient
+from prefect.client.schemas.actions import GlobalConcurrencyLimitCreate
+from prefect.client.schemas.objects import FlowRun
+from prefect.concurrency.sync import concurrency
+from pydantic_ai import Agent
+
+
+@pytest.fixture
+async def crashed_flow_run(prefect_client: PrefectClient) -> FlowRun:
+    """Actually crash a flow run by forcing lease renewal to fail at the HTTP boundary.
+
+    Patches:
+    - `_RENEWAL_FRACTION` / `_RENEWAL_MAX_ATTEMPTS` / `_RENEWAL_RETRY_BASE_DELAY`
+      so the failure surfaces within seconds instead of the production cadence.
+    - `SyncPrefectClient.renew_concurrency_lease` raises `httpx.ConnectError`,
+      simulating the network blip Prefect's renewal retries are meant to absorb.
+
+    Everything downstream of the patched call - retry/backoff, `get_run_logger()`
+    emitting the "Concurrency lease renewal failed" message, the watcher
+    cancel scope, and the resulting CRASHED state - runs for real.
+    """
+    limit_name = f"db-connection-pool-{uuid4().hex[:8]}"
+    await prefect_client.create_global_concurrency_limit(
+        concurrency_limit=GlobalConcurrencyLimitCreate(name=limit_name, limit=1)
+    )
+
+    def failing_renew(
+        self: SyncPrefectClient, lease_id: object, lease_duration: float
+    ) -> None:
+        raise httpx.ConnectError("Simulated network failure during lease renewal")
+
+    @flow(name=f"db-sync-job-{uuid4().hex[:8]}")
+    def db_sync_job() -> str:
+        # strict=True -> raise_on_lease_renewal_failure=True, so a real renewal
+        # failure cancels the cancel scope and crashes the run.
+        # lease_duration=60 is the minimum the API accepts; _RENEWAL_FRACTION=0.01
+        # below makes the first renewal attempt fire ~0.6s into the sleep.
+        with concurrency(limit_name, occupy=1, strict=True, lease_duration=60):
+            import time
+
+            time.sleep(3)
+        return "done"
+
+    with (
+        mock.patch("prefect.concurrency._leases._RENEWAL_FRACTION", 0.01),
+        mock.patch("prefect.concurrency._leases._RENEWAL_MAX_ATTEMPTS", 1),
+        mock.patch("prefect.concurrency._leases._RENEWAL_RETRY_BASE_DELAY", 0.1),
+        mock.patch.object(SyncPrefectClient, "renew_concurrency_lease", failing_renew),
+    ):
+        try:
+            db_sync_job(return_state=True)
+        except BaseException:
+            # CancelledError from the cancel scope is a BaseException
+            pass
+
+    runs = await prefect_client.read_flow_runs()
+    assert runs, "expected a flow run to have been recorded"
+    return runs[0]
+
+
+async def test_diagnoses_lease_renewal_failure(
+    simple_agent: Agent,
+    crashed_flow_run: FlowRun,
+    evaluate_response: Callable[[str, str], Awaitable[None]],
+) -> None:
+    """Agent should diagnose the CRASHED run as a concurrency lease renewal failure."""
+    assert crashed_flow_run.state is not None
+    assert crashed_flow_run.state.type.value == "CRASHED", (
+        f"expected CRASHED but got {crashed_flow_run.state.type.value}; "
+        f"message={crashed_flow_run.state.message!r}"
+    )
+
+    prompt = f"My flow run '{crashed_flow_run.name}' crashed. What happened?"
+
+    async with simple_agent:
+        result = await simple_agent.run(prompt)
+
+    await evaluate_response(
+        "Does the agent identify that the crash was due to concurrency lease "
+        "renewal failure? The response should mention 'lease' or that "
+        "concurrency slot reservation could not be maintained.",
+        result.output,
+    )


### PR DESCRIPTION
closes #97

## summary

adds a new eval (`test_lease_renewal_crash`) for issue #97 - tests that an agent can diagnose flow runs that crashed due to concurrency lease renewal failures.

based on real user issues:
- https://github.com/PrefectHQ/prefect/issues/19068
- https://github.com/PrefectHQ/prefect/issues/18839

## changes

- **new**: `evals/test_lease_renewal_crash.py` - eval for concurrency lease renewal crash diagnosis
- **updated**: README with new eval

## test plan

- [x] `test_lease_renewal_crash` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)