### PR TITLE
Bump server.json version to 0.0.1-beta.9

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.PrefectHQ/prefect-mcp-server",
   "title": "Prefect MCP Server",
   "description": "MCP server for Prefect. Monitor and debug workflows, deployments, and automations.",
-  "version": "0.0.1-beta.7",
+  "version": "0.0.1-beta.9",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "prefect-mcp",
-      "version": "0.0.1-beta.7",
+      "version": "0.0.1-beta.9",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## summary

updates `server.json` version from 0.0.1-beta.7 to 0.0.1-beta.9, skipping beta.8 since it was already published to PyPI (but failed MCP registry publishing due to version mismatch).

## context

- 0.0.1-beta.8 release partially succeeded (PyPI) but failed on MCP registry
- PR #105 added validation to prevent this in the future
- this PR prepares for a clean 0.0.1-beta.9 release where both PyPI and MCP registry will succeed

## changes

- bumped `version` field to 0.0.1-beta.9
- bumped `packages[0].version` field to 0.0.1-beta.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)