### PR TITLE
feat(tool/delete-deployment): added the delete deployment tool

### DIFF
--- a/src/prefect_mcp_server/_prefect_client/__init__.py
+++ b/src/prefect_mcp_server/_prefect_client/__init__.py
@@ -3,7 +3,10 @@
 from prefect_mcp_server._prefect_client.automations import get_automations
 from prefect_mcp_server._prefect_client.client import get_prefect_client
 from prefect_mcp_server._prefect_client.dashboard import fetch_dashboard
-from prefect_mcp_server._prefect_client.deployments import get_deployments
+from prefect_mcp_server._prefect_client.deployments import (
+    delete_deployment,
+    get_deployments,
+)
 from prefect_mcp_server._prefect_client.events import fetch_events
 from prefect_mcp_server._prefect_client.flow_runs import (
     get_flow_run,
@@ -21,6 +24,7 @@ __all__ = [
     "fetch_events",
     "get_automations",
     "get_deployments",
+    "delete_deployment",
     "get_flow_run",
     "get_flow_run_logs",
     "get_flow_runs",

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from typing import Annotated, Any, Literal
+from uuid import UUID
 
 import prefect.main  # noqa: F401 - Import to resolve Pydantic forward references
 from fastmcp import FastMCP
@@ -15,6 +16,7 @@ from prefect_mcp_server.settings import settings
 from prefect_mcp_server.types import (
     AutomationsResult,
     DashboardResult,
+    DeploymentDeletionResult,
     DeploymentsResult,
     EventsResult,
     FlowRunsResult,
@@ -115,6 +117,22 @@ async def get_deployments(
         filter=filter,
         limit=limit,
     )
+
+
+@mcp.tool
+async def delete_deployment(
+    deployment_id: Annotated[
+        UUID, Field(description="The id of the deployment to delete")
+    ],
+) -> DeploymentDeletionResult:
+    """Delete a specific deployment given its id.
+
+    Returns the deployment deletion operation's result.
+
+    Examples:
+        - Delete specific deployment: delete_deployment(deployment_id="<deployment-id>")
+    """
+    return await _prefect_client.delete_deployment(deployment_id=deployment_id)
 
 
 @mcp.tool

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -242,6 +242,13 @@ class DeploymentsResult(TypedDict):
     error: str | None
 
 
+class DeploymentDeletionResult(TypedDict):
+    """Result of deleting a deployment"""
+
+    success: bool
+    error: str | None
+
+
 class FlowRunDetail(TypedDict):
     """Detailed flow run information with inlined relationships."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -84,6 +84,29 @@ async def test_get_deployments_with_test_data(
         assert data["deployments"][0]["name"] == "test-deployment-0"
 
 
+async def test_delete_deployment_with_test_data(
+    prefect_mcp_server: FastMCP, prefect_client: PrefectClient, test_flow: UUID
+):
+    """Test deleting deployment returns deletion result"""
+    deployment_id = await prefect_client.create_deployment(
+        flow_id=test_flow,
+        name="test-deployment",
+        description="Test deployment",
+        tags=["test", "deployment"],
+    )
+    async with Client(prefect_mcp_server) as client:
+        result = await client.call_tool(
+            "delete_deployment", {"deployment_id": deployment_id}
+        )
+
+        assert hasattr(result, "structured_content")
+        # FastMCP wraps the result in a 'result' key
+        data = result.structured_content.get("result") or result.structured_content
+
+        assert data["success"] is True
+        assert data["error"] is None
+
+
 async def test_identity_tool(prefect_mcp_server: FastMCP) -> None:
     """Test the identity tool exists and works correctly."""
     async with Client(prefect_mcp_server) as client:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,6 +6,7 @@ from pydantic import TypeAdapter
 from prefect_mcp_server.types import (
     AutomationsResult,
     DashboardResult,
+    DeploymentDeletionResult,
     DeploymentsResult,
     EventsResult,
     FlowRunsResult,
@@ -24,6 +25,7 @@ from prefect_mcp_server.types import (
         AutomationsResult,
         DashboardResult,
         DeploymentsResult,
+        DeploymentDeletionResult,
         EventsResult,
         FlowRunsResult,
         FlowsResult,


### PR DESCRIPTION
## 🔥 Summary

This PR adds a new mcp tool : `delete-deployment`

## 🛠️ What’s Changed

- added integration for the delete_deployment using prefect client
- added type for deployment deletion result
- added mcp tool delete-deployment

## 📌 Motivation / Context

By having a mcp tool like `delete-deployment`, mcp clients will be able to better interact with deployments, providing a way to delete them using LLMs.

This can be useful if you want to easily manage your platform through LLM or in an agentic way.

## 🧪 How I Tested

- Added unit tests for delete_deployment integration and the mcp tool
- Tested the mcp tool manually through claude desktop : first created a deployment and then asked the LLM to delete the deployment named ...