### PR TITLE
add Claude Code plugin with cli skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "prefect",
+  "description": "Prefect workflow orchestration - read-only MCP server for diagnostics, CLI skill for mutations",
+  "author": {
+    "name": "Prefect Technologies",
+    "email": "help@prefect.io",
+    "url": "https://github.com/prefecthq"
+  },
+  "repository": "https://github.com/prefecthq/prefect-mcp-server",
+  "keywords": [
+    "prefect",
+    "workflows",
+    "orchestration",
+    "data-pipelines",
+    "flow-runs",
+    "observability"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "mcp-server": {
+    "command": "uvx",
+    "args": ["--from", "prefect-mcp", "prefect-mcp-server"]
+  }
+}

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: cli
+description: Prefect CLI commands for mutations. The MCP server is read-only - use this skill when you need to trigger deployments, cancel flow runs, create automations, or modify Prefect resources.
+---
+
+# Prefect CLI
+
+The MCP server is read-only. For mutations, use the CLI (or SDK).
+
+## Common Commands
+
+| Task | Command |
+|------|---------|
+| Trigger deployment | `prefect deployment run <name>` |
+| Cancel flow run | `prefect flow-run cancel <id>` |
+| Delete flow run | `prefect flow-run delete <id>` |
+| Create automation | `prefect automation create --file automation.yaml` |
+| Pause deployment | `prefect deployment pause <name>` |
+
+## Automation Creation
+
+For complex automations, write a YAML file then apply:
+
+```bash
+prefect automation create --file automation.yaml
+```
+
+Use `get_automations()` to inspect existing automation schemas for reference.


### PR DESCRIPTION
## Summary

Adds support for installing prefect-mcp-server as a Claude Code plugin, bundling both the MCP server and a companion skill that teaches Claude to use the CLI for mutations.

## Hierarchy

```
Plugin: prefect
├── MCP Server: mcp-server   ← read-only tools for diagnostics
└── Skill: cli               ← teaches CLI usage for mutations
```

**In Claude Code this shows as:** `plugin:prefect:mcp-server`

## Structure

```
.claude-plugin/
└── plugin.json        # plugin manifest
.mcp.json              # MCP server configuration  
skills/
└── cli/
    └── SKILL.md       # ~30 lines, ~200 tokens
```

## The Skill Teaches

MCP is read-only for diagnostics. Use CLI for mutations:

| Task | CLI Command |
|------|-------------|
| Trigger deployment | `prefect deployment run <name>` |
| Cancel flow run | `prefect flow-run cancel <id>` |
| Delete flow run | `prefect flow-run delete <id>` |
| Create automation | `prefect automation create --file automation.yaml` |

## Installation

```bash
/plugin marketplace add prefecthq/prefect-mcp-server
/plugin install prefect
```

## References

- [Agent Skills spec](https://agentskills.io/)
- [MCPval blog post](https://dev-log.prefect.io/mcpval/) - our eval-driven approach
- #111 - future reference files investigation

## Test plan

- [ ] Plugin installs from local dev marketplace
- [ ] MCP server starts (`plugin:prefect:mcp-server` appears)
- [ ] Skill loads and teaches CLI pattern for mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)