### PR TITLE
feat(deploy): add GKE deployment infrastructure

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+# Prefect Cloud credentials for local development
+# Get from ~/.prefect/profiles.toml or Prefect Cloud UI
+#
+# For Translucent shared workspace (default):
+PREFECT_API_URL=https://api.prefect.cloud/api/accounts/aa4dbf21-6e5e-4105-b6c4-5d64216a7a5a/workspaces/62856747-7675-419d-827d-20aa5712ba77
+PREFECT_API_KEY=pnu_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Note: For open-source Prefect servers with basic auth, use PREFECT_API_AUTH_STRING instead:
+# PREFECT_API_AUTH_STRING=username:password

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,24 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ci:
+    uses: translucent-ai/github-workflows/.github/workflows/python-uv-ci.yml@v2.4.0
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+      pull-requests: write
+    with:
+      app-name: prefect-mcp-server
+      run-type-check: false
+      run-tests: true
+      run-lint: true
+      publish-environments: '["dev"]'
+    secrets:
+      BOT_PAT: ${{ secrets.BOT_PAT }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Platform team owns this repository
+* @translucent-ai/platform @translucent-ai/product

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Builder stage - has shell and package management tools
+FROM python:3.11-slim AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Change the working directory to the `app` directory
+WORKDIR /app
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --link-mode=copy
+
+# Copy the project into the image
+ADD . /app
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --link-mode=copy
+
+# Production stage - distroless (no shell, minimal attack surface)
+ARG PYTHON_VERSION=3.11
+FROM gcr.io/distroless/python3-debian12:nonroot
+
+WORKDIR /app
+
+# Copy the entire virtual environment
+COPY --from=builder /app/.venv /app/.venv
+
+# Copy the application code
+COPY --from=builder /app/src /app/src
+COPY --from=builder /app/pyproject.toml /app/pyproject.toml
+
+# Expose port for MCP server (standardized on 8080)
+EXPOSE 8080
+
+# Set port environment variable
+ENV PORT=8080
+
+# Set Python path to include the virtual environment and source directories
+ENV PYTHONPATH=/app/.venv/lib/python3.11/site-packages:/app/src:/app
+
+# Run as non-root user (uid 65532 by default in distroless :nonroot)
+# No USER directive needed - already non-root
+
+# Run the MCP server with the distroless Python
+ENTRYPOINT ["/usr/bin/python3"]
+CMD ["-m", "prefect_mcp_server"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,48 @@
+# Development Dockerfile with hot reload support
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv standalone to a globally accessible location
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    cp /root/.local/bin/uv /usr/local/bin/uv && \
+    chmod 755 /usr/local/bin/uv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install all dependencies including dev dependencies (for watchdog/watchmedo)
+RUN uv sync --all-extras --no-install-project
+
+# Add venv to PATH for runtime
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Set Python path to include the source directories
+ENV PYTHONPATH=/app/src:/app
+
+# Copy the application code
+COPY src/ ./src/
+
+# Expose port for MCP server
+EXPOSE 8080
+
+# Set port environment variable
+ENV PORT=8080
+
+# Use watchmedo to watch for file changes and auto-restart
+# Watches src/ directory for Python file changes
+CMD ["watchmedo", "auto-restart", \
+     "--directory=./src", \
+     "--pattern=*.py", \
+     "--recursive", \
+     "--", \
+     "python", "-m", "prefect_mcp_server"]

--- a/kubernetes/app/dev/us-central1/deployment-patch.yaml
+++ b/kubernetes/app/dev/us-central1/deployment-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefect-mcp-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: prefect-mcp-server
+          env:
+            - name: ENVIRONMENT
+              value: dev
+            - name: LOG_LEVEL
+              value: INFO

--- a/kubernetes/app/dev/us-central1/kustomization.yaml
+++ b/kubernetes/app/dev/us-central1/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mcp-server
+
+resources:
+  - ../../../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: prefect-mcp-server
+    path: deployment-patch.yaml

--- a/kubernetes/app/local/deployment-patch.yaml
+++ b/kubernetes/app/local/deployment-patch.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefect-mcp-server
+spec:
+  replicas: 1
+  template:
+    spec:
+      # Remove security context for local dev (Dockerfile.dev runs as root)
+      securityContext: null
+      containers:
+        - name: prefect-mcp-server
+          # Remove container security context for local dev
+          securityContext: null
+          # Reduce resources for local development
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          env:
+            - name: ENVIRONMENT
+              value: "local"
+            - name: LOG_LEVEL
+              value: "DEBUG"
+            - name: PORT
+              value: "8080"
+            # Use central OTEL collector in app namespace
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector.app.svc.cluster.local:4318"
+            # Prefect credentials from secret (created by Tiltfile from .env.local)
+            - name: PREFECT_API_URL
+              valueFrom:
+                secretKeyRef:
+                  name: prefect-mcp-server-secrets
+                  key: PREFECT_API_URL
+            - name: PREFECT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: prefect-mcp-server-secrets
+                  key: PREFECT_API_KEY

--- a/kubernetes/app/local/kustomization.yaml
+++ b/kubernetes/app/local/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mcp-server
+
+resources:
+  - ../../base
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: prefect-mcp-server
+  # Delete ExternalSecrets (not needed locally - created by Tiltfile)
+  - target:
+      kind: ExternalSecret
+      name: prefect-api-key
+    patch: |-
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: prefect-api-key
+      $patch: delete
+  - target:
+      kind: ExternalSecret
+      name: honeycomb-app-namespace-api-key
+    patch: |-
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: honeycomb-app-namespace-api-key
+      $patch: delete
+  # Delete OpenTelemetryCollector (use central otel-collector in app namespace)
+  - target:
+      kind: OpenTelemetryCollector
+      name: prefect-mcp-server-otel
+    patch: |-
+      apiVersion: opentelemetry.io/v1beta1
+      kind: OpenTelemetryCollector
+      metadata:
+        name: prefect-mcp-server-otel
+      $patch: delete
+
+images:
+  - name: app
+    newName: prefect-mcp-server
+    newTag: latest

--- a/kubernetes/base/honeycomb-secret.yaml
+++ b/kubernetes/base/honeycomb-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: honeycomb-app-namespace-api-key
+spec:
+  refreshInterval: "1m"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  target:
+    name: honeycomb-app-namespace-api-key
+  data:
+    - secretKey: HONEYCOMB_API_KEY
+      remoteRef:
+        key: honeycomb_app-namespace-api-key

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -1,0 +1,194 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mcp-server
+
+resources:
+  - namespace.yaml
+  - networkpolicy.yaml
+  - honeycomb-secret.yaml
+  - prefect-api-key-secret.yaml
+  - https://github.com/translucent-ai/kubernetes-resources//base/backend-template
+
+patches:
+  - target:
+      kind: Deployment
+      name: to-be-kustomized
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: prefect-mcp-server
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: prefect-mcp-server
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: prefect-mcp-server
+      - op: replace
+        path: /spec/template/spec/containers/0/name
+        value: prefect-mcp-server
+      - op: replace
+        path: /spec/template/spec/containers/0/ports/0/containerPort
+        value: 8080
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe/httpGet/port
+        value: 8080
+      - op: add
+        path: /spec/template/spec/containers/0/livenessProbe/httpGet/path
+        value: /healthz
+      - op: add
+        path: /spec/template/spec/containers/0/livenessProbe/timeoutSeconds
+        value: 10
+      - op: add
+        path: /spec/template/spec/containers/0/livenessProbe/periodSeconds
+        value: 30
+      - op: add
+        path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+        value: 10
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/httpGet/port
+        value: 8080
+      - op: add
+        path: /spec/template/spec/containers/0/readinessProbe/httpGet/path
+        value: /healthz
+      - op: add
+        path: /spec/template/spec/containers/0/readinessProbe/timeoutSeconds
+        value: 10
+      - op: add
+        path: /spec/template/spec/containers/0/readinessProbe/periodSeconds
+        value: 15
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 250m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 512Mi
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: PORT
+            value: "8080"
+          - name: PREFECT_API_URL
+            value: "https://api.prefect.cloud/api/accounts/aa4dbf21-6e5e-4105-b6c4-5d64216a7a5a/workspaces/62856747-7675-419d-827d-20aa5712ba77"
+          - name: PREFECT_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: prefect-api-key
+                key: key
+          - name: TRANSLUCENT_APP
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['translucent.co/app']
+          - name: TRANSLUCENT_ENV
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['translucent.co/env']
+          - name: TRANSLUCENT_KIND
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['translucent.co/kind']
+          - name: TRANSLUCENT_REGION
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['translucent.co/region']
+          - name: TRANSLUCENT_REPO
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['translucent.co/repo']
+          - name: TRANSLUCENT_VERSION
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['translucent.co/version']
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://prefect-mcp-server-otel-collector:4318"
+      - op: add
+        path: /spec/template/spec/serviceAccountName
+        value: prefect-mcp-server
+      - op: add
+        path: /spec/template/spec/securityContext
+        value:
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+          fsGroup: 65532
+          seccompProfile:
+            type: RuntimeDefault
+      - op: add
+        path: /spec/template/spec/containers/0/securityContext
+        value:
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+      - op: add
+        path: /spec/template/spec/volumes
+        value:
+          - name: tmp-dir
+            emptyDir: {}
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts
+        value:
+          - name: tmp-dir
+            mountPath: /tmp
+
+  - target:
+      kind: Service
+      name: to-be-kustomized
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: prefect-mcp-server
+      - op: replace
+        path: /spec/selector/app
+        value: prefect-mcp-server
+      - op: replace
+        path: /spec/ports/0/port
+        value: 8080
+      - op: replace
+        path: /spec/ports/0/targetPort
+        value: 8080
+
+  - target:
+      kind: ServiceAccount
+      name: to-be-kustomized
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: prefect-mcp-server
+
+  - target:
+      kind: ExternalSecret
+      name: to-be-kustomized
+    patch: |-
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: to-be-kustomized
+      $patch: delete
+
+  - target:
+      kind: OpenTelemetryCollector
+      name: to-be-kustomized
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: prefect-mcp-server-otel
+      - op: add
+        path: /spec/envFrom
+        value:
+          - secretRef:
+              name: honeycomb-app-namespace-api-key
+      - op: add
+        path: /spec/env
+        value:
+          - name: HONEYCOMB_DATASET
+            value: "prefect-mcp-server"

--- a/kubernetes/base/namespace.yaml
+++ b/kubernetes/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-server
+  labels:
+    name: mcp-server

--- a/kubernetes/base/networkpolicy.yaml
+++ b/kubernetes/base/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prefect-mcp-server
+spec:
+  podSelector:
+    matchLabels:
+      app: prefect-mcp-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: app
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - {}

--- a/kubernetes/base/prefect-api-key-secret.yaml
+++ b/kubernetes/base/prefect-api-key-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prefect-api-key
+spec:
+  refreshInterval: "1m"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  target:
+    name: prefect-api-key
+  data:
+    - secretKey: key
+      remoteRef:
+        key: prefect_api-key


### PR DESCRIPTION
## Summary

- Add production Dockerfile with distroless base image for minimal attack surface
- Add Dockerfile.dev for local development with hot reload via watchmedo
- Add kubernetes/base manifests using backend-template from kubernetes-resources
- Add kubernetes/app/dev/us-central1 environment overlay
- Add kubernetes/app/local overlay for Tilt local development
- Add deploy.yaml workflow using centralized github-workflows for CI/CD
- Add CODEOWNERS for Platform/Product teams
- Add .env.local.example for Prefect Cloud credentials

## Test plan

- [ ] Verify Dockerfile builds successfully
- [ ] Verify kustomize build works for all overlays
- [ ] Test local development with Tilt (requires translucent-portal PR)
- [ ] Verify CI workflow runs successfully

Depends on:
- translucent-ai/translucent-portal PR for Tiltfile changes
- translucent-ai/kubernetes-resources PR for ArgoCD application
- Kargo project (run add-project.yaml workflow manually)
