### PR TITLE
fix: restore MCP server config in plugin

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,6 @@
 {
-  "mcpServers": {}
+  "prefect": {
+    "command": "uvx",
+    "args": ["--from", "prefect-mcp", "prefect-mcp-server"]
+  }
 }


### PR DESCRIPTION
## Summary

PR #114 accidentally removed the MCP server definition from `.mcp.json`, leaving an empty object:

```json
{
  "mcpServers": {}
}
```

This caused the plugin to install without any MCP server, making the Prefect tools unavailable.

## Fix

Restored the server configuration:

```json
{
  "prefect": {
    "command": "uvx",
    "args": ["--from", "prefect-mcp", "prefect-mcp-server"]
  }
}
```

## Test plan

- [ ] `/plugin install prefect@prefect` now registers the MCP server
- [ ] Prefect tools appear in Claude Code after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)