### PR TITLE
fix: mark text attribute as non-filterable in turbopuffer writes

### DIFF
--- a/packages/ingestion_pipeline/main.py
+++ b/packages/ingestion_pipeline/main.py
@@ -368,6 +368,9 @@ async def refresh_tpuf_namespace(
                 response = await ns.write(
                     upsert_rows=upsert_batch,  # type: ignore[arg-type]
                     distance_metric="cosine_distance",
+                    schema={
+                        "text": {"type": "string", "filterable": False},
+                    },
                 )
                 batch_affected = response.rows_affected or len(upsert_batch)
                 total_upserted += batch_affected
@@ -379,6 +382,9 @@ async def refresh_tpuf_namespace(
             response = await ns.write(
                 upsert_rows=pending_documents,  # type: ignore[arg-type]
                 distance_metric="cosine_distance",
+                schema={
+                    "text": {"type": "string", "filterable": False},
+                },
             )
             batch_affected = response.rows_affected or len(pending_documents)
             total_upserted += batch_affected


### PR DESCRIPTION
## Summary
- Marks the `text` attribute as `filterable: False` in turbopuffer `ns.write()` schema config
- Fixes `BadRequestError` when text chunks exceed turbopuffer's 4096-byte filterable attribute limit
- The `text` attribute is only used for retrieval (`include_attributes`), never for filtering, so this has no impact on the docs MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)