### PR TITLE
ci(prefecthq-prefect-mcp-server): add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "prefect-mcp-server",
+  "version": "0.1.0",
+  "description": "Prefect MCP server",
+  "author": {
+    "name": "PrefectHQ",
+    "url": "https://github.com/PrefectHQ"
+  },
+  "homepage": "https://github.com/PrefectHQ/prefect-mcp-server",
+  "repository": "https://github.com/PrefectHQ/prefect-mcp-server",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,26 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@df9c8a41eefff30cc430344c2a32c7a96bf37645
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical


### PR DESCRIPTION
This adds a small metadata pass so the repo is easier to wire into Codex without touching runtime code.

I targeted this repo because it already exposes:
- An MCP server for interacting with prefect resources
- /plugin marketplace add prefecthq/prefect-mcp-server
- Fork this repository on GitHub (gh repo fork prefecthq/prefect-mcp-server)

It adds `.codex-plugin/plugin.json`, a starter `.mcp.json`, and the scanner workflow.
Permissions: read-only. No secrets. No publish. No runtime changes.
If you want different command wiring or metadata values, I can adjust the branch.