### PR TITLE
Handle service account MCP OAuth identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,37 @@ Useful first prompts:
 > [!NOTE]
 > The Cloud OAuth MCP path is for Prefect Cloud. Local stdio usage and self-hosted Prefect deployments continue to use local profiles, environment variables, API keys, basic auth, or HTTP headers.
 
+### Unattended Service-Account Clients
+
+Browser OAuth is the right flow for human-operated MCP clients. Workflow agents and other noninteractive runtimes should use service-account MCP OAuth credentials issued by Prefect Cloud, exchange those credentials for a short-lived MCP bearer token, and connect to the hosted MCP URL with an `Authorization` header.
+
+```bash
+export PREFECT_MCP_CLOUD_ENVIRONMENT=stg
+export PREFECT_MCP_CLOUD_CLIENT_ID=...
+export PREFECT_MCP_CLOUD_CLIENT_SECRET=...
+
+uvx --from prefect-mcp prefect-mcp-cloud-token
+```
+
+Agents can also exchange credentials in process before constructing their MCP client:
+
+```python
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+from prefect_mcp_server.cloud_oauth import exchange_client_credentials
+
+token = await exchange_client_credentials()
+transport = StreamableHttpTransport(
+    url="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+    headers={"Authorization": f"Bearer {token}"},
+)
+
+async with Client(transport) as client:
+    print(await client.list_tools())
+```
+
+Tokens are intentionally short-lived. Long-running agents should refresh the token before expiry using the same client credentials.
+
 ## Claude Code Plugin
 
 The easiest local setup for Claude Code is the Prefect plugin:
@@ -143,6 +174,8 @@ Cloud OAuth settings use the `PREFECT_MCP_CLOUD_` prefix:
 | `PREFECT_MCP_CLOUD_API_BASE_URL` | Optional override for the Prefect API base URL |
 | `PREFECT_MCP_CLOUD_AUTH_BASE_URL` | Optional override for auth helper endpoints |
 | `PREFECT_MCP_CLOUD_AUTHORIZATION_SERVER` | Optional override for advertised OAuth authorization server |
+| `PREFECT_MCP_CLOUD_CLIENT_ID` | Optional service-account MCP OAuth client id for unattended token exchange |
+| `PREFECT_MCP_CLOUD_CLIENT_SECRET` | Optional service-account MCP OAuth client secret for unattended token exchange |
 | `PREFECT_MCP_CLOUD_PUBLIC_BASE_URL` | Public base URL for the hosted MCP server |
 | `PREFECT_MCP_PUBLIC_BASE_URL` | Legacy alias for the public base URL |
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ Useful first prompts:
 
 ### Unattended Service-Account Clients
 
-Browser OAuth is the right flow for human-operated MCP clients. Workflow agents and other noninteractive runtimes should use service-account MCP OAuth credentials issued by Prefect Cloud, exchange those credentials for a short-lived MCP bearer token, and connect to the hosted MCP URL with an `Authorization` header.
+Browser OAuth is the right flow for human-operated MCP clients. Workflow agents and other noninteractive runtimes should use service-account MCP OAuth credentials issued by Prefect Cloud, exchange those credentials for an MCP bearer token, and connect to the hosted MCP URL with an `Authorization` header.
 
 ```bash
-export PREFECT_MCP_CLOUD_ENVIRONMENT=stg
 export PREFECT_MCP_CLOUD_CLIENT_ID=...
 export PREFECT_MCP_CLOUD_CLIENT_SECRET=...
 
@@ -67,19 +66,19 @@ Agents can also exchange credentials in process before constructing their MCP cl
 ```python
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
-from prefect_mcp_server.cloud_oauth import exchange_client_credentials
+from prefect_mcp_server.cloud_oauth import exchange_client_credentials_token
 
-token = await exchange_client_credentials()
+token = await exchange_client_credentials_token()
 transport = StreamableHttpTransport(
     url="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
-    headers={"Authorization": f"Bearer {token}"},
+    headers={"Authorization": f"Bearer {token.access_token}"},
 )
 
 async with Client(transport) as client:
     print(await client.list_tools())
 ```
 
-Tokens are intentionally short-lived. Long-running agents should refresh the token before expiry using the same client credentials.
+The token response includes `expires_in`. Treat an agent as long-running if it may keep using the MCP connection longer than that returned lifetime. In that case, request a new token with the same client credentials before reusing the MCP connection. This follows the OAuth client-credentials pattern: the client credentials are the renewable secret, and the access token is the time-limited bearer credential sent to the MCP server.
 
 ## Claude Code Plugin
 
@@ -156,7 +155,6 @@ Prefect-operated Cloud OAuth deployments use a dedicated entrypoint:
 
 - server path: `src/prefect_mcp_server/cloud.py`
 - required runtime secret: `PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY`
-- optional environment selector: `PREFECT_MCP_CLOUD_ENVIRONMENT=stg` or `prod`
 
 This entrypoint reuses the same read-only tool definitions as the local/API-key server, adds Prefect Cloud OAuth, and adds Cloud OAuth-only workspace discovery. If OAuth is not configured, the Cloud OAuth entrypoint fails at import time instead of starting an unprotected server.
 
@@ -170,7 +168,6 @@ Cloud OAuth settings use the `PREFECT_MCP_CLOUD_` prefix:
 | Environment variable | Purpose |
 | --- | --- |
 | `PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY` | Required signing/verification key for Prefect Cloud issued MCP OAuth access tokens |
-| `PREFECT_MCP_CLOUD_ENVIRONMENT` | `prod`, `stg`, or `local`; defaults to `prod` |
 | `PREFECT_MCP_CLOUD_API_BASE_URL` | Optional override for the Prefect API base URL |
 | `PREFECT_MCP_CLOUD_AUTH_BASE_URL` | Optional override for auth helper endpoints |
 | `PREFECT_MCP_CLOUD_AUTHORIZATION_SERVER` | Optional override for advertised OAuth authorization server |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = ["fastmcp>=3.0.0", "prefect>=3.4.22"]
 
 [project.scripts]
 prefect-mcp-server = "prefect_mcp_server.__main__:main"
+prefect-mcp-cloud-token = "prefect_mcp_server.cloud_token:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/src/prefect_mcp_server/_prefect_client/identity.py
+++ b/src/prefect_mcp_server/_prefect_client/identity.py
@@ -2,6 +2,8 @@
 
 from uuid import UUID
 
+from prefect.client.cloud import CloudUnauthorizedError
+
 from prefect_mcp_server import cloud_oauth
 from prefect_mcp_server._prefect_client.client import (
     get_prefect_client,
@@ -16,24 +18,41 @@ from prefect_mcp_server.types import (
 )
 
 
+async def _get_cloud_oauth_identity(
+    access_token: str, workspace_id: UUID | None = None
+) -> CloudOAuthIdentityInfo:
+    workspaces = await cloud_oauth.list_authorized_workspaces(access_token)
+    identity: CloudOAuthIdentityInfo = {
+        "api_url": cloud_oauth.settings.resolved_api_base_url,
+        "auth_mode": "prefect-cloud-oauth",
+        "grant_id": cloud_oauth.grant_id_from_access_token(access_token),
+        "authorized_workspace_count": len(workspaces),
+        "authorized_workspaces": [workspace.as_dict() for workspace in workspaces],
+    }
+    if workspace_id is None:
+        identity["next_step"] = (
+            "Pass one authorized workspace_id to workspace-scoped tools."
+        )
+        return identity
+
+    for workspace in workspaces:
+        if workspace.workspace_id == workspace_id:
+            identity["selected_workspace"] = workspace.as_dict()
+            identity["next_step"] = "Use selected_workspace for workspace-scoped tools."
+            return identity
+
+    raise ValueError(
+        "Workspace is not included in the OAuth consent grant. "
+        "Call list_authorized_workspaces and choose one of those workspace IDs."
+    )
+
+
 async def get_identity(workspace_id: UUID | None = None) -> IdentityResult:
     """Get identity and connection information for the current Prefect instance."""
     try:
         access_token = cloud_oauth.current_oauth_access_token()
         if workspace_id is None and cloud_oauth.settings.enabled and access_token:
-            workspaces = await cloud_oauth.list_authorized_workspaces(access_token)
-            identity: CloudOAuthIdentityInfo = {
-                "api_url": cloud_oauth.settings.resolved_api_base_url,
-                "auth_mode": "prefect-cloud-oauth",
-                "grant_id": cloud_oauth.grant_id_from_access_token(access_token),
-                "authorized_workspace_count": len(workspaces),
-                "authorized_workspaces": [
-                    workspace.as_dict() for workspace in workspaces
-                ],
-                "next_step": (
-                    "Pass one authorized workspace_id to workspace-scoped tools."
-                ),
-            }
+            identity = await _get_cloud_oauth_identity(access_token)
             return {
                 "success": True,
                 "identity": identity,
@@ -54,7 +73,20 @@ async def get_identity(workspace_id: UUID | None = None) -> IdentityResult:
                     workspace_id=workspace_id
                 ) as cloud_client:
                     # Get user info from /me/ endpoint
-                    me_data = await cloud_client.get("/me/")
+                    try:
+                        me_data = await cloud_client.get("/me/")
+                    except CloudUnauthorizedError:
+                        if cloud_oauth.settings.enabled and access_token:
+                            identity = await _get_cloud_oauth_identity(
+                                access_token, workspace_id=workspace_id
+                            )
+                            return {
+                                "success": True,
+                                "identity": identity,
+                                "error": None,
+                            }
+                        raise
+
                     user_info: UserInfo = {
                         "id": str(me_data.get("id")) if me_data.get("id") else None,
                         "email": me_data.get("email"),

--- a/src/prefect_mcp_server/cloud_oauth.py
+++ b/src/prefect_mcp_server/cloud_oauth.py
@@ -110,6 +110,14 @@ class WorkspaceRef:
         }
 
 
+@dataclass(frozen=True)
+class ClientCredentialsToken:
+    access_token: str
+    token_type: str
+    expires_in: int
+    scope: str
+
+
 settings = CloudOAuthSettings()
 
 
@@ -250,13 +258,13 @@ async def require_authorized_workspace(workspace_id: UUID) -> WorkspaceRef:
     )
 
 
-async def exchange_client_credentials(
+async def exchange_client_credentials_token(
     *,
     client_id: str | None = None,
     client_secret: str | None = None,
     scope: str = "prefect-cloud:workspaces",
-) -> str:
-    """Exchange service-account MCP OAuth credentials for a bearer token."""
+) -> ClientCredentialsToken:
+    """Exchange service-account MCP OAuth credentials for token metadata."""
     resolved_client_id = client_id or settings.client_id
     resolved_client_secret = client_secret or settings.client_secret
     if not resolved_client_id or not resolved_client_secret:
@@ -280,4 +288,33 @@ async def exchange_client_credentials(
     access_token = body.get("access_token")
     if not isinstance(access_token, str) or not access_token:
         raise RuntimeError("Prefect Cloud did not return an MCP access token.")
-    return access_token
+    token_type = body.get("token_type")
+    if not isinstance(token_type, str) or token_type.lower() != "bearer":
+        raise RuntimeError("Prefect Cloud did not return a bearer token.")
+    expires_in = body.get("expires_in")
+    if not isinstance(expires_in, int) or expires_in <= 0:
+        raise RuntimeError("Prefect Cloud did not return a token expiration.")
+    returned_scope = body.get("scope")
+    if not isinstance(returned_scope, str) or not returned_scope:
+        raise RuntimeError("Prefect Cloud did not return a token scope.")
+    return ClientCredentialsToken(
+        access_token=access_token,
+        token_type=token_type,
+        expires_in=expires_in,
+        scope=returned_scope,
+    )
+
+
+async def exchange_client_credentials(
+    *,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    scope: str = "prefect-cloud:workspaces",
+) -> str:
+    """Exchange service-account MCP OAuth credentials for a bearer token."""
+    token = await exchange_client_credentials_token(
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+    )
+    return token.access_token

--- a/src/prefect_mcp_server/cloud_oauth.py
+++ b/src/prefect_mcp_server/cloud_oauth.py
@@ -55,6 +55,8 @@ class CloudOAuthSettings(BaseSettings):
     auth_issuer: str = Field(default="AuthServerID")
     auth_audience: str = Field(default="AuthServerID")
     auth_algorithm: str = Field(default="HS256")
+    client_id: str | None = Field(default=None)
+    client_secret: str | None = Field(default=None)
 
     @property
     def enabled(self) -> bool:
@@ -246,3 +248,36 @@ async def require_authorized_workspace(workspace_id: UUID) -> WorkspaceRef:
         "Workspace is not included in the OAuth consent grant. "
         "Call list_authorized_workspaces and choose one of those workspace IDs."
     )
+
+
+async def exchange_client_credentials(
+    *,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    scope: str = "prefect-cloud:workspaces",
+) -> str:
+    """Exchange service-account MCP OAuth credentials for a bearer token."""
+    resolved_client_id = client_id or settings.client_id
+    resolved_client_secret = client_secret or settings.client_secret
+    if not resolved_client_id or not resolved_client_secret:
+        raise RuntimeError(
+            "PREFECT_MCP_CLOUD_CLIENT_ID and PREFECT_MCP_CLOUD_CLIENT_SECRET "
+            "are required for service-account MCP credential exchange."
+        )
+
+    async with httpx.AsyncClient(
+        base_url=settings.resolved_auth_base_url,
+        auth=(resolved_client_id, resolved_client_secret),
+        timeout=10.0,
+    ) as client:
+        response = await client.post(
+            "/auth/mcp/oauth/token",
+            data={"grant_type": "client_credentials", "scope": scope},
+        )
+        response.raise_for_status()
+
+    body = response.json()
+    access_token = body.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise RuntimeError("Prefect Cloud did not return an MCP access token.")
+    return access_token

--- a/src/prefect_mcp_server/cloud_token.py
+++ b/src/prefect_mcp_server/cloud_token.py
@@ -1,0 +1,46 @@
+"""CLI for Prefect Cloud MCP service-account token exchange."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from prefect_mcp_server.cloud_oauth import exchange_client_credentials
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Exchange service-account MCP OAuth credentials for a bearer token."
+    )
+    parser.add_argument(
+        "--client-id",
+        default=None,
+        help="MCP OAuth client id. Defaults to PREFECT_MCP_CLOUD_CLIENT_ID.",
+    )
+    parser.add_argument(
+        "--client-secret",
+        default=None,
+        help="MCP OAuth client secret. Defaults to PREFECT_MCP_CLOUD_CLIENT_SECRET.",
+    )
+    parser.add_argument(
+        "--scope",
+        default="prefect-cloud:workspaces",
+        help="OAuth scope to request.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    token = asyncio.run(
+        exchange_client_credentials(
+            client_id=args.client_id,
+            client_secret=args.client_secret,
+            scope=args.scope,
+        )
+    )
+    print(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -425,6 +425,7 @@ class CloudOAuthIdentityInfo(TypedDict, total=False):
     grant_id: str | None
     authorized_workspace_count: int
     authorized_workspaces: list[dict[str, str | None]]
+    selected_workspace: dict[str, str | None]
     next_step: str
 
 

--- a/tests/test_cloud_oauth.py
+++ b/tests/test_cloud_oauth.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import pytest
 from fastmcp import Client
 from fastmcp.server.auth.providers.jwt import JWTVerifier
+from prefect.client.cloud import CloudUnauthorizedError
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
@@ -137,6 +138,73 @@ async def test_get_identity_describes_oauth_grant_without_workspace() -> None:
     )
 
 
+async def test_get_identity_describes_service_account_oauth_grant_with_workspace() -> (
+    None
+):
+    workspace = cloud_oauth.WorkspaceRef(
+        account_id=ACCOUNT_ID,
+        account_handle="acme",
+        workspace_id=WORKSPACE_ID,
+        workspace_handle="prod",
+    )
+    mock_client = AsyncMock()
+    mock_client.api_url = (
+        f"https://api.prefect.cloud/api/accounts/{ACCOUNT_ID}/workspaces/{WORKSPACE_ID}"
+    )
+    mock_cloud_client = AsyncMock()
+    mock_cloud_client.get = AsyncMock(
+        side_effect=CloudUnauthorizedError(
+            "Only users (not service accounts) can access this endpoint."
+        )
+    )
+
+    with (
+        patch(
+            "prefect_mcp_server.cloud_oauth.current_oauth_access_token",
+            return_value="header.eyJtY3BfZ3JhbnRfaWQiOiAiZ3JhbnQtMSJ9.signature",
+        ),
+        patch(
+            "prefect_mcp_server._prefect_client.identity.get_prefect_client"
+        ) as mock_get_client,
+        patch(
+            "prefect_mcp_server._prefect_client.identity.get_prefect_cloud_client"
+        ) as mock_get_cloud_client,
+        patch(
+            "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.enabled",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch(
+            "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.resolved_api_base_url",
+            new_callable=PropertyMock,
+            return_value="https://api.prefect.cloud",
+        ),
+        patch(
+            "prefect_mcp_server.cloud_oauth.list_authorized_workspaces",
+            AsyncMock(return_value=[workspace]),
+        ) as mock_list_authorized_workspaces,
+    ):
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+        mock_get_cloud_client.return_value.__aenter__.return_value = mock_cloud_client
+        mock_get_cloud_client.return_value.__aexit__.return_value = None
+
+        result = await get_identity(workspace_id=WORKSPACE_ID)
+
+    assert result["success"] is True
+    assert result["identity"] == {
+        "api_url": "https://api.prefect.cloud",
+        "auth_mode": "prefect-cloud-oauth",
+        "grant_id": "grant-1",
+        "authorized_workspace_count": 1,
+        "authorized_workspaces": [workspace.as_dict()],
+        "selected_workspace": workspace.as_dict(),
+        "next_step": "Use selected_workspace for workspace-scoped tools.",
+    }
+    mock_list_authorized_workspaces.assert_awaited_once_with(
+        "header.eyJtY3BfZ3JhbnRfaWQiOiAiZ3JhbnQtMSJ9.signature"
+    )
+
+
 async def test_default_server_excludes_cloud_oauth_workspace_tools() -> None:
     server = build_prefect_mcp_server(
         include_docs_proxy=False,
@@ -225,8 +293,13 @@ async def test_exchange_client_credentials_posts_oauth_request(
         def raise_for_status(self) -> None:
             pass
 
-        def json(self) -> dict[str, str]:
-            return {"access_token": "mcp-access-token"}
+        def json(self) -> dict[str, str | int]:
+            return {
+                "access_token": "mcp-access-token",
+                "token_type": "bearer",
+                "expires_in": 1800,
+                "scope": "prefect-cloud:workspaces",
+            }
 
     class Client:
         def __init__(self, **kwargs):
@@ -251,12 +324,21 @@ async def test_exchange_client_credentials_posts_oauth_request(
     monkeypatch.setattr(cloud_oauth.settings, "environment", "stg")
     monkeypatch.setattr(cloud_oauth.httpx, "AsyncClient", Client)
 
-    token = await cloud_oauth.exchange_client_credentials(
+    token = await cloud_oauth.exchange_client_credentials_token(
         client_id="client-id",
         client_secret="client-secret",
     )
 
-    assert token == "mcp-access-token"
+    assert token.access_token == "mcp-access-token"
+    assert token.token_type == "bearer"
+    assert token.expires_in == 1800
+    assert token.scope == "prefect-cloud:workspaces"
+
+    token_string = await cloud_oauth.exchange_client_credentials(
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+    assert token_string == "mcp-access-token"
 
 
 def test_exchange_client_credentials_requires_credentials(

--- a/tests/test_cloud_oauth.py
+++ b/tests/test_cloud_oauth.py
@@ -1,5 +1,6 @@
 """Tests for Prefect Cloud OAuth support."""
 
+import asyncio
 from unittest.mock import AsyncMock, PropertyMock, patch
 from uuid import UUID
 
@@ -215,3 +216,54 @@ def test_protected_resource_metadata_preserves_authorization_server_origin() -> 
 
     assert response.status_code == 200
     assert response.json()["authorization_servers"] == ["https://api.prefect.cloud"]
+
+
+async def test_exchange_client_credentials_posts_oauth_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict[str, str]:
+            return {"access_token": "mcp-access-token"}
+
+    class Client:
+        def __init__(self, **kwargs):
+            assert kwargs["base_url"] == "https://api.stg.prefect.dev"
+            assert kwargs["auth"] == ("client-id", "client-secret")
+            assert kwargs["timeout"] == 10.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def post(self, path: str, *, data: dict[str, str]):
+            assert path == "/auth/mcp/oauth/token"
+            assert data == {
+                "grant_type": "client_credentials",
+                "scope": "prefect-cloud:workspaces",
+            }
+            return Response()
+
+    monkeypatch.setattr(cloud_oauth.settings, "environment", "stg")
+    monkeypatch.setattr(cloud_oauth.httpx, "AsyncClient", Client)
+
+    token = await cloud_oauth.exchange_client_credentials(
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+    assert token == "mcp-access-token"
+
+
+def test_exchange_client_credentials_requires_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloud_oauth.settings, "client_id", None)
+    monkeypatch.setattr(cloud_oauth.settings, "client_secret", None)
+
+    with pytest.raises(RuntimeError, match="PREFECT_MCP_CLOUD_CLIENT_ID"):
+        asyncio.run(cloud_oauth.exchange_client_credentials())

--- a/tests/test_cloud_token.py
+++ b/tests/test_cloud_token.py
@@ -1,0 +1,48 @@
+"""Tests for the Prefect Cloud MCP token CLI."""
+
+from __future__ import annotations
+
+import sys
+
+from prefect_mcp_server import cloud_token
+
+
+def test_cloud_token_cli_prints_exchanged_token(
+    monkeypatch,
+    capsys,
+) -> None:
+    calls = []
+
+    async def exchange_client_credentials(**kwargs) -> str:
+        calls.append(kwargs)
+        return "mcp-access-token"
+
+    monkeypatch.setattr(
+        cloud_token,
+        "exchange_client_credentials",
+        exchange_client_credentials,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prefect-mcp-cloud-token",
+            "--client-id",
+            "client-id",
+            "--client-secret",
+            "client-secret",
+            "--scope",
+            "prefect-cloud:workspaces",
+        ],
+    )
+
+    cloud_token.main()
+
+    assert capsys.readouterr().out == "mcp-access-token\n"
+    assert calls == [
+        {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scope": "prefect-cloud:workspaces",
+        }
+    ]


### PR DESCRIPTION
## Summary

This fills in the noninteractive side of hosted Prefect Cloud MCP usage. Browser OAuth remains the right flow for human-operated clients; workflow agents and other unattended runtimes can now exchange Prefect Cloud-issued service-account MCP OAuth credentials for a time-limited bearer token and pass that token to the hosted MCP HTTP endpoint.

It also fixes `get_identity` for that service-account path. Service-account MCP tokens correctly cannot call `/me/`, so `get_identity` now falls back to describing the OAuth grant and selected workspace when `/me/` rejects a hosted OAuth token. Existing user/API-key Cloud identity behavior still uses `/me/` and is unchanged.

## Details

<details>
<summary>implementation notes</summary>

- Adds `PREFECT_MCP_CLOUD_CLIENT_ID` / `PREFECT_MCP_CLOUD_CLIENT_SECRET` settings.
- Adds `exchange_client_credentials_token()` for `client_credentials` token exchange against `/auth/mcp/oauth/token`, including `expires_in`, `token_type`, and `scope` from the OAuth response.
- Keeps `exchange_client_credentials()` as a simple compatibility helper that returns just the access-token string.
- Adds `prefect-mcp-cloud-token` as a small CLI for shell/client setup.
- Adds `selected_workspace` to the Cloud OAuth identity payload when `get_identity` receives a workspace id.

</details>

## Validation

- `uv run --project /Users/nate/github.com/prefecthq/prefect-mcp-server pytest -q tests/test_cloud_oauth.py tests/test_cloud_token.py tests/test_identity.py`
- `uv run --all-packages pre-commit run --all-files`
- CI: lint, tests, and evals passed before the latest doc/helper refinement; rerunning after push.
- Staging E2E smoke: created a throwaway Owner service account in stg, rotated MCP OAuth client credentials through the public stg API, exchanged `client_credentials` for an MCP bearer, connected a real FastMCP client to this branch running as an HTTP Cloud MCP server, and verified `get_identity`, `list_authorized_workspaces`, and `get_flows`. The smoke revoked the MCP credentials and deleted the throwaway service account afterward.
