### PR TITLE
Add execution plan MCP authoring surface

### DIFF
--- a/src/prefect_mcp_server/_prefect_client/__init__.py
+++ b/src/prefect_mcp_server/_prefect_client/__init__.py
@@ -5,6 +5,7 @@ from prefect_mcp_server._prefect_client.client import get_prefect_client
 from prefect_mcp_server._prefect_client.dashboard import fetch_dashboard
 from prefect_mcp_server._prefect_client.deployments import get_deployments
 from prefect_mcp_server._prefect_client.events import fetch_events
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
 from prefect_mcp_server._prefect_client.flow_runs import (
     get_flow_run,
     get_flow_run_logs,
@@ -19,6 +20,7 @@ from prefect_mcp_server._prefect_client.work_pools import get_work_pool, get_wor
 __all__ = [
     "fetch_dashboard",
     "fetch_events",
+    "call_execution_plan_api",
     "get_automations",
     "get_deployments",
     "get_flow_run",

--- a/src/prefect_mcp_server/_prefect_client/execution_plans.py
+++ b/src/prefect_mcp_server/_prefect_client/execution_plans.py
@@ -6,6 +6,16 @@ from uuid import UUID
 from prefect_mcp_server._prefect_client.client import get_prefect_client
 
 ExecutionPlanApiMethod = Literal["GET", "POST", "PATCH", "DELETE"]
+PREFECT_CLOUD_WORKSPACE_API_HINT = (
+    "Execution plans are only available for Prefect Cloud workspaces. "
+    "Configure a Prefect Cloud workspace API URL or use Prefect Cloud OAuth "
+    "with an authorized workspace_id."
+)
+
+
+def is_cloud_workspace_api_url(api_url: str) -> bool:
+    """Return whether an API URL points at a Prefect Cloud workspace."""
+    return "/accounts/" in api_url and "/workspaces/" in api_url
 
 
 async def call_execution_plan_api(
@@ -18,14 +28,20 @@ async def call_execution_plan_api(
 ) -> Any:
     """Call a workspace-relative execution-plan Cloud API route.
 
-    The execution-plan MCP tools intentionally go through the same Prefect
-    client factory as existing tools so OAuth workspace consent, header auth,
-    environment credentials, and local profiles keep one shared boundary.
+    Execution plans are a Prefect Cloud-only surface. The tools still go
+    through the shared Prefect client factory so OAuth workspace consent,
+    Cloud header credentials, environment credentials, and local Cloud profiles
+    keep one auth boundary, but the resolved client must target a Cloud
+    workspace URL before any execution-plan request is sent.
     """
     if not path.startswith("/"):
         raise ValueError("Execution-plan API paths must start with '/'.")
 
     async with get_prefect_client(workspace_id=workspace_id) as client:
+        api_url = str(client.api_url)
+        if not is_cloud_workspace_api_url(api_url):
+            raise RuntimeError(PREFECT_CLOUD_WORKSPACE_API_HINT)
+
         response = await client.request(
             method,
             cast(Any, path),

--- a/src/prefect_mcp_server/_prefect_client/execution_plans.py
+++ b/src/prefect_mcp_server/_prefect_client/execution_plans.py
@@ -1,0 +1,38 @@
+"""Execution-plan Cloud API boundary for Prefect MCP tools."""
+
+from typing import Any, Literal, cast
+from uuid import UUID
+
+from prefect_mcp_server._prefect_client.client import get_prefect_client
+
+ExecutionPlanApiMethod = Literal["GET", "POST", "PATCH", "DELETE"]
+
+
+async def call_execution_plan_api(
+    method: ExecutionPlanApiMethod,
+    path: str,
+    *,
+    workspace_id: UUID | None = None,
+    json: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """Call a workspace-relative execution-plan Cloud API route.
+
+    The execution-plan MCP tools intentionally go through the same Prefect
+    client factory as existing tools so OAuth workspace consent, header auth,
+    environment credentials, and local profiles keep one shared boundary.
+    """
+    if not path.startswith("/"):
+        raise ValueError("Execution-plan API paths must start with '/'.")
+
+    async with get_prefect_client(workspace_id=workspace_id) as client:
+        response = await client.request(
+            method,
+            cast(Any, path),
+            json=json,
+            params=params,
+        )
+        response.raise_for_status()
+        if not response.content:
+            return None
+        return response.json()

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -1,0 +1,40 @@
+"""Execution-plan authoring MCP namespace."""
+
+from collections.abc import Mapping
+from typing import Any
+
+EXECUTION_PLANS_NAMESPACE = "execution_plans"
+EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
+EXECUTION_PLAN_TOOL_NAMES: set[str] = set()
+EXECUTION_PLAN_API_BOUNDARY = (
+    "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
+    "through get_prefect_client(workspace_id=...)."
+)
+EXECUTION_PLAN_AUTH_CONTEXT = (
+    "Uses existing Prefect MCP auth, workspace scoping, OAuth consent, header "
+    "credentials, and local profile fallback."
+)
+
+
+def execution_plans_disabled_response(
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return an agent-readable disabled response for the execution-plan surface."""
+    workspace_id = arguments.get("workspace_id")
+    return {
+        "success": False,
+        "enabled": False,
+        "namespace": EXECUTION_PLANS_NAMESPACE,
+        "schema_version": EXECUTION_PLAN_SCHEMA_VERSION,
+        "workspace_id": str(workspace_id) if workspace_id else None,
+        "api_boundary": EXECUTION_PLAN_API_BOUNDARY,
+        "auth_context": EXECUTION_PLAN_AUTH_CONTEXT,
+        "error": (
+            "Execution-plan authoring is disabled for this MCP server. "
+            "Set PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true to enable the "
+            "execution_plans namespace."
+        ),
+    }
+
+
+EXECUTION_PLAN_TOOLS = ()

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -1,18 +1,43 @@
 """Execution-plan authoring MCP namespace."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from pydantic import Field
+
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
+from prefect_mcp_server.types import (
+    ExecutionPlansValidateResult,
+    ExecutionPlanValidationError,
+)
+
+WorkspaceId = Annotated[
+    UUID,
+    Field(
+        description="Prefect Cloud workspace ID. Required when using Prefect Cloud OAuth mode.",
+    ),
+]
+ExecutionPlanDocument = Annotated[
+    dict[str, Any],
+    Field(
+        description=(
+            "Authored execution plan document to validate. The tool sends this "
+            "document to Prefect Cloud as {'plan': <document>}."
+        ),
+    ),
+]
 
 EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
-EXECUTION_PLAN_TOOL_NAMES: set[str] = set()
+EXECUTION_PLAN_TOOL_NAMES = {"execution_plans_validate"}
 EXECUTION_PLAN_API_BOUNDARY = (
-    "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
-    "through get_prefect_client(workspace_id=...)."
+    "Execution-plan MCP tools are Cloud-only and use workspace-relative "
+    "Prefect Cloud API routes through get_prefect_client(workspace_id=...)."
 )
 EXECUTION_PLAN_AUTH_CONTEXT = (
-    "Uses existing Prefect MCP auth, workspace scoping, OAuth consent, header "
-    "credentials, and local profile fallback."
+    "Uses Prefect Cloud OAuth workspace scoping, Cloud workspace API "
+    "credentials from headers or environment, and local Cloud profile fallback."
 )
 
 
@@ -32,9 +57,44 @@ def execution_plans_disabled_response(
         "error": (
             "Execution-plan authoring is disabled for this MCP server. "
             "Set PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true to enable the "
-            "execution_plans namespace."
+            "Cloud-only execution_plans namespace."
         ),
     }
 
 
-EXECUTION_PLAN_TOOLS = ()
+async def execution_plans_validate(
+    plan: ExecutionPlanDocument,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansValidateResult:
+    """Validate an authored execution-plan draft without saving a plan version."""
+    try:
+        response = await call_execution_plan_api(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": plan},
+        )
+    except Exception as exc:
+        return {
+            "success": False,
+            "valid": None,
+            "errors": [],
+            "workspace_id": str(workspace_id) if workspace_id else None,
+            "error": f"Failed to validate execution plan: {str(exc)}",
+        }
+
+    validation_response = cast(dict[str, Any], response)
+    validation_errors = cast(
+        list[ExecutionPlanValidationError],
+        validation_response.get("errors", []),
+    )
+
+    return {
+        "success": True,
+        "valid": cast(bool, validation_response["valid"]),
+        "errors": validation_errors,
+        "workspace_id": str(workspace_id) if workspace_id else None,
+        "error": None,
+    }
+
+EXECUTION_PLAN_TOOLS = (execution_plans_validate,)

--- a/src/prefect_mcp_server/middleware.py
+++ b/src/prefect_mcp_server/middleware.py
@@ -1,13 +1,68 @@
 """middleware for prefect mcp server."""
 
 import logging
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import mcp.types as mt
 from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import Tool, ToolResult
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FeatureFlag:
+    """Configuration for one feature-gated tool namespace."""
+
+    enabled: Callable[[], bool]
+    tool_names: frozenset[str]
+    disabled_response: Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+class FeatureFlagMiddleware(Middleware):
+    """Return feature-specific disabled responses for gated tools."""
+
+    def __init__(self, features: Sequence[FeatureFlag]) -> None:
+        self._features = tuple(features)
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, Any],
+    ) -> Any:
+        """Short-circuit calls to known tools for disabled features."""
+        tool_name = context.message.name
+        arguments = context.message.arguments or {}
+
+        for feature in self._features:
+            if tool_name in feature.tool_names and not feature.enabled():
+                return ToolResult(
+                    structured_content=feature.disabled_response(arguments)
+                )
+
+        return await call_next(context)
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        """Hide tools for disabled features from tool discovery."""
+        tools = await call_next(context)
+        disabled_tool_names = {
+            tool_name
+            for feature in self._features
+            if not feature.enabled()
+            for tool_name in feature.tool_names
+        }
+
+        if not disabled_tool_names:
+            return tools
+
+        return [tool for tool in tools if tool.name not in disabled_tool_names]
 
 
 class PrefectAuthMiddleware(Middleware):

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -12,8 +12,12 @@ from fastmcp.server.providers.proxy import ProxyClient
 from prefect.client.base import ServerType, determine_server_type
 from pydantic import Field
 
-from prefect_mcp_server import _prefect_client, cloud_oauth
-from prefect_mcp_server.middleware import PrefectAuthMiddleware
+from prefect_mcp_server import _prefect_client, cloud_oauth, execution_plans
+from prefect_mcp_server.middleware import (
+    FeatureFlag,
+    FeatureFlagMiddleware,
+    PrefectAuthMiddleware,
+)
 from prefect_mcp_server.settings import settings
 from prefect_mcp_server.types import (
     AutomationsResult,
@@ -545,6 +549,7 @@ CORE_TOOLS = (
 
 CLOUD_TOOLS = (review_rate_limits,)
 CLOUD_OAUTH_TOOLS = (list_authorized_workspaces,)
+EXECUTION_PLAN_TOOLS = execution_plans.EXECUTION_PLAN_TOOLS
 
 
 def build_prefect_mcp_server(
@@ -558,6 +563,17 @@ def build_prefect_mcp_server(
     """Build a Prefect MCP server from shared tools and optional Cloud adapters."""
     server = FastMCP(name, auth=auth_provider)
     server.add_middleware(PrefectAuthMiddleware())
+    server.add_middleware(
+        FeatureFlagMiddleware(
+            features=(
+                FeatureFlag(
+                    enabled=lambda: settings.experimental.execution_plans_enabled,
+                    tool_names=frozenset(execution_plans.EXECUTION_PLAN_TOOL_NAMES),
+                    disabled_response=execution_plans.execution_plans_disabled_response,
+                ),
+            )
+        )
+    )
 
     if include_docs_proxy:
         docs_proxy = create_proxy(
@@ -584,6 +600,9 @@ def build_prefect_mcp_server(
     if include_cloud_oauth_tools:
         for tool in CLOUD_OAUTH_TOOLS:
             server.add_tool(tool)
+
+    for tool in EXECUTION_PLAN_TOOLS:
+        server.add_tool(tool)
 
     return server
 

--- a/src/prefect_mcp_server/settings.py
+++ b/src/prefect_mcp_server/settings.py
@@ -48,6 +48,21 @@ class LogfireSettings(BaseSettings):
     )
 
 
+class ExperimentalSettings(BaseSettings):
+    """Experimental MCP feature settings."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_MCP_EXPERIMENTAL_",
+        extra="ignore",
+        env_file=".env",
+    )
+
+    execution_plans_enabled: bool = Field(
+        default=False,
+        description="Whether to enable the experimental execution-plan authoring MCP surface",
+    )
+
+
 class Settings(BaseSettings):
     """Settings for the Prefect MCP server."""
 
@@ -66,6 +81,11 @@ class Settings(BaseSettings):
     logfire: LogfireSettings = Field(
         default_factory=LogfireSettings,
         description="Logfire settings",
+    )
+
+    experimental: ExperimentalSettings = Field(
+        default_factory=ExperimentalSettings,
+        description="Experimental MCP feature settings",
     )
 
 

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 from typing_extensions import NotRequired, TypedDict
@@ -534,4 +534,23 @@ class RateLimitsResult(TypedDict):
     until: str | None
     summary: RateLimitSummary | None
     throttling_periods: list[ThrottlingPeriod] | None
+    error: str | None
+
+
+class ExecutionPlanValidationError(TypedDict):
+    """Validation issue returned by the Prefect Cloud execution-plan API."""
+
+    code: str
+    phase: Literal["document_shape", "semantic"]
+    path: list[str | int]
+    message: str
+
+
+class ExecutionPlansValidateResult(TypedDict):
+    """Result of validating an authored execution-plan document."""
+
+    success: bool
+    valid: bool | None
+    errors: list[ExecutionPlanValidationError]
+    workspace_id: str | None
     error: str | None

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -1,0 +1,145 @@
+"""Tests for execution-plan MCP authoring surface."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from fastmcp import Client
+
+from prefect_mcp_server import execution_plans
+from prefect_mcp_server import server as server_module
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
+from prefect_mcp_server.server import build_prefect_mcp_server
+from prefect_mcp_server.settings import ExperimentalSettings, settings
+
+
+@pytest.fixture
+def workspace_id() -> UUID:
+    """Return a workspace ID for execution-plan authoring tests."""
+    return UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.fixture
+def api_response() -> MagicMock:
+    """Return a JSON HTTP response for execution-plan helper tests."""
+    response = MagicMock()
+    response.content = b'{"ok": true}'
+    response.json.return_value = {"ok": True}
+    response.raise_for_status.return_value = None
+    return response
+
+
+async def execution_plans_test_tool(
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the provided workspace ID from a feature-gated test tool."""
+    return {"success": True, "workspace_id": workspace_id}
+
+
+@pytest.fixture
+def registered_execution_plan_test_tool(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Register a temporary execution-plan tool through the server registry."""
+    tool_name = "execution_plans_test_tool"
+    monkeypatch.setattr(execution_plans, "EXECUTION_PLAN_TOOL_NAMES", {tool_name})
+    monkeypatch.setattr(
+        server_module,
+        "EXECUTION_PLAN_TOOLS",
+        (execution_plans_test_tool,),
+    )
+    return tool_name
+
+
+def test_experimental_setting_reads_execution_plans_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED", "true")
+
+    assert ExperimentalSettings().execution_plans_enabled is True
+
+
+async def test_disabled_execution_plan_tools_are_hidden_from_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_execution_plan_test_tool: str,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+
+    assert registered_execution_plan_test_tool not in {tool.name for tool in tools}
+
+
+async def test_disabled_execution_plan_direct_call_returns_structured_response(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_execution_plan_test_tool: str,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            registered_execution_plan_test_tool,
+            {"workspace_id": str(workspace_id)},
+        )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["enabled"] is False
+    assert data["namespace"] == execution_plans.EXECUTION_PLANS_NAMESPACE
+    assert data["workspace_id"] == str(workspace_id)
+    assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+
+
+async def test_enabled_execution_plan_tools_are_discoverable_and_callable(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_execution_plan_test_tool: str,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        result = await client.call_tool(
+            registered_execution_plan_test_tool,
+            {"workspace_id": str(workspace_id)},
+        )
+
+    assert registered_execution_plan_test_tool in {tool.name for tool in tools}
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {"success": True, "workspace_id": str(workspace_id)}
+
+
+async def test_execution_plan_api_helper_uses_workspace_client(
+    workspace_id: UUID,
+    api_response: MagicMock,
+) -> None:
+    route = "/flows/00000000-0000-0000-0000-000000000001/execution-plan/validate"
+    payload = {"schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION}
+
+    with patch(
+        "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=api_response)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        result = await call_execution_plan_api(
+            "POST",
+            route,
+            workspace_id=workspace_id,
+            json=payload,
+        )
+
+    assert result == {"ok": True}
+    mock_get_client.assert_called_once_with(workspace_id=workspace_id)
+    mock_client.request.assert_awaited_once_with(
+        "POST",
+        route,
+        json=payload,
+        params=None,
+    )
+    api_response.raise_for_status.assert_called_once()

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -50,6 +50,178 @@ def registered_execution_plan_test_tool(monkeypatch: pytest.MonkeyPatch) -> str:
     return tool_name
 
 
+@pytest.fixture
+def valid_execution_plan() -> dict[str, Any]:
+    """Return a valid authored execution-plan document."""
+    return {
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "kind": "ExecutionPlan",
+        "nodes": {},
+        "edges": [],
+    }
+
+
+async def test_execution_plans_tools_report_disabled_when_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tool_names = {tool.name for tool in await client.list_tools()}
+        result = await client.call_tool(
+            "execution_plans_validate",
+            {"workspace_id": str(workspace_id)},
+        )
+
+    assert "execution_plans_validate" not in tool_names
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["enabled"] is False
+    assert data["namespace"] == "execution_plans"
+    assert data["workspace_id"] == str(workspace_id)
+    assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+    assert "Cloud-only execution_plans namespace" in data["error"]
+
+
+async def test_execution_plans_validate_returns_valid_plan_result(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    api_result = {"valid": True, "errors": []}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=api_result),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {
+        "success": True,
+        "valid": True,
+        "errors": [],
+        "workspace_id": str(workspace_id),
+        "error": None,
+    }
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": valid_execution_plan},
+    )
+
+
+async def test_execution_plans_validate_preserves_schema_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_required_field",
+        "phase": "document_shape",
+        "path": ["nodes", "draft"],
+        "message": "Field required",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["error"] is None
+
+
+async def test_execution_plans_validate_preserves_semantic_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 0, "from", "node"],
+        "message": "Source node 'missing' is not defined.",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["errors"][0]["phase"] == "semantic"
+    assert data["errors"][0]["path"] == ["edges", 0, "from", "node"]
+
+
+async def test_execution_plans_validate_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("workspace authorization failed")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["valid"] is None
+    assert data["errors"] == []
+    assert data["workspace_id"] == str(workspace_id)
+    assert "workspace authorization failed" in data["error"]
+
+
 def test_experimental_setting_reads_execution_plans_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -117,13 +289,23 @@ async def test_execution_plan_api_helper_uses_workspace_client(
     workspace_id: UUID,
     api_response: MagicMock,
 ) -> None:
-    route = "/flows/00000000-0000-0000-0000-000000000001/execution-plan/validate"
-    payload = {"schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION}
+    route = "/execution-plans/validate"
+    payload = {
+        "plan": {
+            "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+            "kind": "ExecutionPlan",
+            "nodes": {},
+            "edges": [],
+        }
+    }
 
     with patch(
         "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
     ) as mock_get_client:
         mock_client = AsyncMock()
+        mock_client.api_url = (
+            "https://api.prefect.cloud/api/accounts/test/workspaces/test"
+        )
         mock_client.request = AsyncMock(return_value=api_response)
         mock_get_client.return_value.__aenter__.return_value = mock_client
 
@@ -143,3 +325,21 @@ async def test_execution_plan_api_helper_uses_workspace_client(
         params=None,
     )
     api_response.raise_for_status.assert_called_once()
+
+
+async def test_execution_plan_api_helper_rejects_non_cloud_workspace_client(
+    api_response: MagicMock,
+) -> None:
+    with patch(
+        "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.api_url = "http://localhost:4200/api"
+        mock_client.request = AsyncMock(return_value=api_response)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="only available for Prefect Cloud"):
+            await call_execution_plan_api("POST", "/execution-plans/validate")
+
+    mock_get_client.assert_called_once_with(workspace_id=None)
+    mock_client.request.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds the root execution-plan authoring infrastructure for the Prefect MCP server.

Key changes:
- Adds a disabled-by-default `PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED` setting under the experimental MCP settings namespace.
- Adds generic feature flag middleware that can hide gated tools from discovery and return structured disabled responses for direct calls.
- Adds the execution-plan disabled-response helper used by the generic feature gate.
- Adds a shared `call_execution_plan_api` helper that routes future tools through the existing Prefect client, auth, and workspace boundary.
- Leaves execution-plan tools and authoring-context behavior to the follow-up issues.

## Stack

Base branch: `main`

This is the root branch for the MCP authoring stack. Downstream branches for `CLOUD-4175` through `CLOUD-4178` stack on this branch.
