### PR TITLE
Expose execution plan authoring context resource

### DIFF
--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -5,6 +5,8 @@ from typing import Any
 
 EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
+EXECUTION_PLAN_AUTHORING_CONTEXT_RESOURCE_NAME = "execution_plans_authoring_context"
+EXECUTION_PLAN_AUTHORING_CONTEXT_URI = "prefect://execution-plans/authoring-context"
 EXECUTION_PLAN_TOOL_NAMES: set[str] = set()
 EXECUTION_PLAN_API_BOUNDARY = (
     "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
@@ -34,6 +36,128 @@ def execution_plans_disabled_response(
             "Set PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true to enable the "
             "execution_plans namespace."
         ),
+    }
+
+
+def execution_plans_authoring_context() -> dict[str, object]:
+    """Return compact execution-plan authoring guidance for MCP agents."""
+    return {
+        "name": EXECUTION_PLAN_AUTHORING_CONTEXT_RESOURCE_NAME,
+        "schema_version": EXECUTION_PLAN_SCHEMA_VERSION,
+        "purpose": (
+            "Compact, non-exhaustive drafting guidance for MVP authored execution "
+            "plans. Prefect Cloud validation is the schema authority."
+        ),
+        "source_of_truth": (
+            "Use execution_plans_validate, once available, to check exact schema "
+            "compatibility before publishing. This resource intentionally does not "
+            "mirror the full Cloud schema."
+        ),
+        "boundaries": [
+            "Static acyclic authored graphs only.",
+            "Mapping, dynamic expansion, and executable loops are out of scope for schema 0.1.",
+            "Runtime controls such as run, schedule, inspect, repair, and publish are out of scope for this resource.",
+        ],
+        "draft_checklist": {
+            "top_level": [
+                "Set schema_version to 0.1 and kind to ExecutionPlan.",
+                "Use nodes as an object keyed by stable node id.",
+                "Use edges as a static list of value transfers between plan inputs and node ports.",
+            ],
+            "nodes": [
+                "Prefer AgentNode for first drafts unless the workflow truly needs human input, timers, or deployments.",
+                "Name every input and output port explicitly and include JSON Schema objects for values.",
+                "Keep orchestration fields simple; do not encode runtime conditions or repair behavior in the authored graph.",
+            ],
+            "edges": [
+                "Use plan_input references for plan inputs and node_output references for node outputs.",
+                "Keep the graph acyclic and model fan-out or fan-in with explicit edges.",
+            ],
+        },
+        "authoring_guidance": [
+            "Keep node ids stable and unique within the plan.",
+            "Keep the first draft small; add lifecycle nodes only after the agent-only graph validates.",
+            "Represent routing with selected output ports and authored edges, not evaluate_when condition objects.",
+            "Reference deployments by id on DeploymentNode; do not embed flow-run controls.",
+        ],
+        "examples": [
+            {
+                "name": "minimal_agent_graph",
+                "description": "Start from one plan input, run one agent, then pass its output to a second agent.",
+                "plan": {
+                    "schema_version": EXECUTION_PLAN_SCHEMA_VERSION,
+                    "kind": "ExecutionPlan",
+                    "inputs": {
+                        "question": {
+                            "schema": {"type": "string"},
+                            "required": True,
+                        }
+                    },
+                    "nodes": {
+                        "research": {
+                            "kind": "AgentNode",
+                            "objective": "Research the question and return concise findings.",
+                            "inputs": {
+                                "question": {
+                                    "schema": {"type": "string"},
+                                    "expects": {
+                                        "cardinality": "exactly_one",
+                                        "shape": "value",
+                                    },
+                                },
+                            },
+                            "outputs": {
+                                "findings": {
+                                    "schema": {"type": "object"},
+                                }
+                            },
+                            "orchestration": {
+                                "output_selection": "exactly_one",
+                                "evaluate_when": "all_reachable_terminal",
+                            },
+                        },
+                        "summarize": {
+                            "kind": "AgentNode",
+                            "objective": "Summarize the findings into a final response.",
+                            "inputs": {
+                                "findings": {
+                                    "schema": {"type": "object"},
+                                    "expects": {
+                                        "cardinality": "exactly_one",
+                                        "shape": "value",
+                                    },
+                                },
+                            },
+                            "outputs": {
+                                "response": {
+                                    "schema": {"type": "object"},
+                                }
+                            },
+                            "orchestration": {
+                                "output_selection": "exactly_one",
+                                "evaluate_when": "all_reachable_terminal",
+                            },
+                        },
+                    },
+                    "edges": [
+                        {
+                            "id": "question_to_research",
+                            "from": {"type": "plan_input", "input": "question"},
+                            "to": {"node": "research", "input": "question"},
+                        },
+                        {
+                            "id": "research_to_summarize",
+                            "from": {
+                                "type": "node_output",
+                                "node": "research",
+                                "output": "findings",
+                            },
+                            "to": {"node": "summarize", "input": "findings"},
+                        },
+                    ],
+                },
+            },
+        ],
     }
 
 

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -604,6 +604,14 @@ def build_prefect_mcp_server(
     for tool in EXECUTION_PLAN_TOOLS:
         server.add_tool(tool)
 
+    if settings.experimental.execution_plans_enabled:
+        server.resource(
+            execution_plans.EXECUTION_PLAN_AUTHORING_CONTEXT_URI,
+            name=execution_plans.EXECUTION_PLAN_AUTHORING_CONTEXT_RESOURCE_NAME,
+            description="Compact authoring context for MVP execution-plan drafts.",
+            mime_type="application/json",
+        )(execution_plans.execution_plans_authoring_context)
+
     return server
 
 

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -1,6 +1,7 @@
 """Tests for execution-plan MCP authoring surface."""
 
-from typing import Any
+import json
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -48,6 +49,191 @@ def registered_execution_plan_test_tool(monkeypatch: pytest.MonkeyPatch) -> str:
         (execution_plans_test_tool,),
     )
     return tool_name
+
+
+@pytest.fixture
+def authoring_context() -> dict[str, Any]:
+    """Return the execution-plan authoring context resource payload."""
+    return execution_plans.execution_plans_authoring_context()
+
+
+@pytest.fixture
+def authoring_examples(authoring_context: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return example plans from the authoring context."""
+    return cast(list[dict[str, Any]], authoring_context["examples"])
+
+
+async def test_execution_plans_authoring_context_resource_reports_compact_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        resources = await client.list_resources()
+        contents = await client.read_resource(
+            execution_plans.EXECUTION_PLAN_AUTHORING_CONTEXT_URI
+        )
+
+    matching_resource = next(
+        resource
+        for resource in resources
+        if resource.name
+        == execution_plans.EXECUTION_PLAN_AUTHORING_CONTEXT_RESOURCE_NAME
+    )
+    assert str(matching_resource.uri) == (
+        execution_plans.EXECUTION_PLAN_AUTHORING_CONTEXT_URI
+    )
+    assert matching_resource.mimeType == "application/json"
+
+    assert len(contents) == 1
+    content = contents[0]
+    assert content.mimeType == "application/json"
+
+    data = json.loads(content.text)
+    assert (
+        data["name"] == execution_plans.EXECUTION_PLAN_AUTHORING_CONTEXT_RESOURCE_NAME
+    )
+    assert data["schema_version"] == execution_plans.EXECUTION_PLAN_SCHEMA_VERSION
+    assert "Prefect Cloud validation is the schema authority" in data["purpose"]
+    assert (
+        "intentionally does not mirror the full Cloud schema" in data["source_of_truth"]
+    )
+    assert "Static acyclic" in data["boundaries"][0]
+    assert "schema_reference" not in data
+    assert "draft_checklist" in data
+    assert len(json.dumps(data)) < 3500
+    assert [example["name"] for example in data["examples"]] == [
+        "minimal_agent_graph",
+    ]
+
+
+def test_execution_plans_authoring_context_points_to_cloud_validation(
+    authoring_context: dict[str, Any],
+) -> None:
+    assert authoring_context["schema_version"] == (
+        execution_plans.EXECUTION_PLAN_SCHEMA_VERSION
+    )
+    assert authoring_context["boundaries"] == [
+        "Static acyclic authored graphs only.",
+        "Mapping, dynamic expansion, and executable loops are out of scope for schema 0.1.",
+        "Runtime controls such as run, schedule, inspect, repair, and publish are out of scope for this resource.",
+    ]
+    checklist = cast(dict[str, list[str]], authoring_context["draft_checklist"])
+    assert "execution_plans_validate" in authoring_context["source_of_truth"]
+    assert "schema_reference" not in authoring_context
+    assert "valid_combinations" not in json.dumps(authoring_context)
+    assert "full Cloud schema" in authoring_context["source_of_truth"]
+    assert any("schema_version" in item for item in checklist["top_level"])
+    assert any("AgentNode" in item for item in checklist["nodes"])
+
+
+def test_execution_plans_authoring_context_omits_deployment_slug_guidance(
+    authoring_context: dict[str, Any],
+) -> None:
+    context_text = json.dumps(authoring_context).lower()
+
+    assert "or slug" not in context_text
+    assert "slug" not in context_text
+
+
+def test_execution_plans_authoring_context_examples_are_static_mvp_dags(
+    authoring_examples: list[dict[str, Any]],
+) -> None:
+    assert len(authoring_examples) == 1
+    for example in authoring_examples:
+        plan = cast(dict[str, Any], example["plan"])
+        nodes = cast(dict[str, dict[str, Any]], plan["nodes"])
+        edges = cast(list[dict[str, Any]], plan["edges"])
+        plan_inputs = cast(dict[str, Any], plan["inputs"])
+
+        assert {"schema_version", "kind", "nodes", "edges"}.issubset(plan)
+        assert set(plan) <= {"schema_version", "kind", "inputs", "nodes", "edges"}
+        assert plan["schema_version"] == execution_plans.EXECUTION_PLAN_SCHEMA_VERSION
+        assert plan["kind"] == "ExecutionPlan"
+        assert nodes
+        assert edges
+
+        for input_spec in plan_inputs.values():
+            assert set(input_spec) <= {"schema", "required"}
+            assert "description" not in input_spec
+            assert "schema" in input_spec
+
+        incoming_counts = {node_id: 0 for node_id in nodes}
+        outgoing_edges = {node_id: [] for node_id in nodes}
+
+        for node_id, node in nodes.items():
+            assert "id" not in node
+            assert node["kind"] == "AgentNode"
+            assert "output_selection" not in node
+            assert "evaluate_when" not in node
+            assert isinstance(node["objective"], str)
+            assert node["objective"]
+
+            orchestration = cast(dict[str, str], node["orchestration"])
+            assert set(orchestration) == {"output_selection", "evaluate_when"}
+            assert orchestration["output_selection"] == "exactly_one"
+            assert orchestration["evaluate_when"] == "all_reachable_terminal"
+
+            node_outputs = cast(dict[str, Any], node["outputs"])
+            for output_spec in node_outputs.values():
+                assert "schema" in output_spec
+
+            node_inputs = cast(dict[str, Any], node.get("inputs", {}))
+            for port_spec in node_inputs.values():
+                expects = cast(dict[str, str], port_spec["expects"])
+                assert "schema" in port_spec
+                assert "mode" not in expects
+                assert expects["cardinality"] == "exactly_one"
+                assert expects["shape"] == "value"
+                assert "key_by" not in expects
+
+        edge_ids = set()
+
+        for edge in edges:
+            source = cast(dict[str, str], edge["from"])
+            target = cast(dict[str, str], edge["to"])
+            target_node = target["node"]
+            target_input = target["input"]
+
+            assert set(edge) == {"id", "from", "to"}
+            assert edge["id"] not in edge_ids
+            edge_ids.add(edge["id"])
+            assert target_node in nodes
+            assert set(target) == {"node", "input"}
+            target_inputs = cast(dict[str, Any], nodes[target_node]["inputs"])
+            assert target_input in target_inputs
+
+            if source["type"] == "plan_input":
+                assert set(source) == {"type", "input"}
+                assert source["input"] in plan_inputs
+            else:
+                assert source["type"] == "node_output"
+                assert set(source) == {"type", "node", "output"}
+                source_node = source["node"]
+                source_output = source["output"]
+                assert source_node in nodes
+                source_outputs = cast(dict[str, Any], nodes[source_node]["outputs"])
+                assert source_output in source_outputs
+
+                outgoing_edges[source_node].append(target_node)
+                incoming_counts[target_node] += 1
+
+        ready = [
+            node_id
+            for node_id, incoming_count in incoming_counts.items()
+            if incoming_count == 0
+        ]
+        visited_count = 0
+        while ready:
+            node_id = ready.pop()
+            visited_count += 1
+            for downstream_node_id in outgoing_edges[node_id]:
+                incoming_counts[downstream_node_id] -= 1
+                if incoming_counts[downstream_node_id] == 0:
+                    ready.append(downstream_node_id)
+
+        assert visited_count == len(nodes)
 
 
 def test_experimental_setting_reads_execution_plans_env_var(


### PR DESCRIPTION
## Summary
- add the `prefect://execution-plans/authoring-context` resource behind the experimental execution-plan feature flag
- include compact schema guidance for execution-plan 0.1 authoring, node kinds, orchestration enums, valid input expectation combinations, and example DAGs
- hide the resource when the experimental feature flag is disabled

## Notes
- Stacked on #169.
- The resource examples were checked against the current Cloud execution-plan schema implementation from the local Nebula worktree.
