### PR TITLE
Add execution plan validation tool

### DIFF
--- a/src/prefect_mcp_server/_prefect_client/execution_plans.py
+++ b/src/prefect_mcp_server/_prefect_client/execution_plans.py
@@ -6,6 +6,16 @@ from uuid import UUID
 from prefect_mcp_server._prefect_client.client import get_prefect_client
 
 ExecutionPlanApiMethod = Literal["GET", "POST", "PATCH", "DELETE"]
+PREFECT_CLOUD_WORKSPACE_API_HINT = (
+    "Execution plans are only available for Prefect Cloud workspaces. "
+    "Configure a Prefect Cloud workspace API URL or use Prefect Cloud OAuth "
+    "with an authorized workspace_id."
+)
+
+
+def is_cloud_workspace_api_url(api_url: str) -> bool:
+    """Return whether an API URL points at a Prefect Cloud workspace."""
+    return "/accounts/" in api_url and "/workspaces/" in api_url
 
 
 async def call_execution_plan_api(
@@ -18,14 +28,20 @@ async def call_execution_plan_api(
 ) -> Any:
     """Call a workspace-relative execution-plan Cloud API route.
 
-    The execution-plan MCP tools intentionally go through the same Prefect
-    client factory as existing tools so OAuth workspace consent, header auth,
-    environment credentials, and local profiles keep one shared boundary.
+    Execution plans are a Prefect Cloud-only surface. The tools still go
+    through the shared Prefect client factory so OAuth workspace consent,
+    Cloud header credentials, environment credentials, and local Cloud profiles
+    keep one auth boundary, but the resolved client must target a Cloud
+    workspace URL before any execution-plan request is sent.
     """
     if not path.startswith("/"):
         raise ValueError("Execution-plan API paths must start with '/'.")
 
     async with get_prefect_client(workspace_id=workspace_id) as client:
+        api_url = str(client.api_url)
+        if not is_cloud_workspace_api_url(api_url):
+            raise RuntimeError(PREFECT_CLOUD_WORKSPACE_API_HINT)
+
         response = await client.request(
             method,
             cast(Any, path),

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -1,11 +1,36 @@
 """Execution-plan authoring MCP namespace."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from pydantic import Field
+
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
+from prefect_mcp_server.types import (
+    ExecutionPlansValidateResult,
+    ExecutionPlanValidationError,
+)
+
+WorkspaceId = Annotated[
+    UUID,
+    Field(
+        description="Prefect Cloud workspace ID. Required when using Prefect Cloud OAuth mode.",
+    ),
+]
+ExecutionPlanDocument = Annotated[
+    dict[str, Any],
+    Field(
+        description=(
+            "Authored execution plan document to validate. The tool sends this "
+            "document to Prefect Cloud as {'plan': <document>}."
+        ),
+    ),
+]
 
 EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
-EXECUTION_PLAN_TOOL_NAMES: set[str] = set()
+EXECUTION_PLAN_TOOL_NAMES = {"execution_plans_validate"}
 EXECUTION_PLAN_API_BOUNDARY = (
     "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
     "through get_prefect_client(workspace_id=...)."
@@ -37,4 +62,40 @@ def execution_plans_disabled_response(
     }
 
 
-EXECUTION_PLAN_TOOLS = ()
+async def execution_plans_validate(
+    plan: ExecutionPlanDocument,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansValidateResult:
+    """Validate an authored execution-plan draft without saving a plan version."""
+    try:
+        response = await call_execution_plan_api(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": plan},
+        )
+    except Exception as exc:
+        return {
+            "success": False,
+            "valid": None,
+            "errors": [],
+            "workspace_id": str(workspace_id) if workspace_id else None,
+            "error": f"Failed to validate execution plan: {str(exc)}",
+        }
+
+    validation_response = cast(dict[str, Any], response)
+    validation_errors = cast(
+        list[ExecutionPlanValidationError],
+        validation_response.get("errors", []),
+    )
+
+    return {
+        "success": True,
+        "valid": cast(bool, validation_response["valid"]),
+        "errors": validation_errors,
+        "workspace_id": str(workspace_id) if workspace_id else None,
+        "error": None,
+    }
+
+
+EXECUTION_PLAN_TOOLS = (execution_plans_validate,)

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -32,12 +32,12 @@ EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
 EXECUTION_PLAN_TOOL_NAMES = {"execution_plans_validate"}
 EXECUTION_PLAN_API_BOUNDARY = (
-    "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
-    "through get_prefect_client(workspace_id=...)."
+    "Execution-plan MCP tools are Cloud-only and use workspace-relative "
+    "Prefect Cloud API routes through get_prefect_client(workspace_id=...)."
 )
 EXECUTION_PLAN_AUTH_CONTEXT = (
-    "Uses existing Prefect MCP auth, workspace scoping, OAuth consent, header "
-    "credentials, and local profile fallback."
+    "Uses Prefect Cloud OAuth workspace scoping, Cloud workspace API "
+    "credentials from headers or environment, and local Cloud profile fallback."
 )
 
 
@@ -57,7 +57,7 @@ def execution_plans_disabled_response(
         "error": (
             "Execution-plan authoring is disabled for this MCP server. "
             "Set PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true to enable the "
-            "execution_plans namespace."
+            "Cloud-only execution_plans namespace."
         ),
     }
 
@@ -96,6 +96,5 @@ async def execution_plans_validate(
         "workspace_id": str(workspace_id) if workspace_id else None,
         "error": None,
     }
-
 
 EXECUTION_PLAN_TOOLS = (execution_plans_validate,)

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 from typing_extensions import NotRequired, TypedDict
@@ -534,4 +534,23 @@ class RateLimitsResult(TypedDict):
     until: str | None
     summary: RateLimitSummary | None
     throttling_periods: list[ThrottlingPeriod] | None
+    error: str | None
+
+
+class ExecutionPlanValidationError(TypedDict):
+    """Validation issue returned by the Prefect Cloud execution-plan API."""
+
+    code: str
+    phase: Literal["document_shape", "semantic"]
+    path: list[str | int]
+    message: str
+
+
+class ExecutionPlansValidateResult(TypedDict):
+    """Result of validating an authored execution-plan document."""
+
+    success: bool
+    valid: bool | None
+    errors: list[ExecutionPlanValidationError]
+    workspace_id: str | None
     error: str | None

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -83,6 +83,7 @@ async def test_execution_plans_tools_report_disabled_when_hidden(
     assert data["namespace"] == "execution_plans"
     assert data["workspace_id"] == str(workspace_id)
     assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+    assert "Cloud-only execution_plans namespace" in data["error"]
 
 
 async def test_execution_plans_validate_returns_valid_plan_result(
@@ -302,6 +303,9 @@ async def test_execution_plan_api_helper_uses_workspace_client(
         "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
     ) as mock_get_client:
         mock_client = AsyncMock()
+        mock_client.api_url = (
+            "https://api.prefect.cloud/api/accounts/test/workspaces/test"
+        )
         mock_client.request = AsyncMock(return_value=api_response)
         mock_get_client.return_value.__aenter__.return_value = mock_client
 
@@ -321,3 +325,21 @@ async def test_execution_plan_api_helper_uses_workspace_client(
         params=None,
     )
     api_response.raise_for_status.assert_called_once()
+
+
+async def test_execution_plan_api_helper_rejects_non_cloud_workspace_client(
+    api_response: MagicMock,
+) -> None:
+    with patch(
+        "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.api_url = "http://localhost:4200/api"
+        mock_client.request = AsyncMock(return_value=api_response)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="only available for Prefect Cloud"):
+            await call_execution_plan_api("POST", "/execution-plans/validate")
+
+    mock_get_client.assert_called_once_with(workspace_id=None)
+    mock_client.request.assert_not_awaited()

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -50,6 +50,177 @@ def registered_execution_plan_test_tool(monkeypatch: pytest.MonkeyPatch) -> str:
     return tool_name
 
 
+@pytest.fixture
+def valid_execution_plan() -> dict[str, Any]:
+    """Return a valid authored execution-plan document."""
+    return {
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "kind": "ExecutionPlan",
+        "nodes": {},
+        "edges": [],
+    }
+
+
+async def test_execution_plans_tools_report_disabled_when_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tool_names = {tool.name for tool in await client.list_tools()}
+        result = await client.call_tool(
+            "execution_plans_validate",
+            {"workspace_id": str(workspace_id)},
+        )
+
+    assert "execution_plans_validate" not in tool_names
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["enabled"] is False
+    assert data["namespace"] == "execution_plans"
+    assert data["workspace_id"] == str(workspace_id)
+    assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+
+
+async def test_execution_plans_validate_returns_valid_plan_result(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    api_result = {"valid": True, "errors": []}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=api_result),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {
+        "success": True,
+        "valid": True,
+        "errors": [],
+        "workspace_id": str(workspace_id),
+        "error": None,
+    }
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": valid_execution_plan},
+    )
+
+
+async def test_execution_plans_validate_preserves_schema_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_required_field",
+        "phase": "document_shape",
+        "path": ["nodes", "draft"],
+        "message": "Field required",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["error"] is None
+
+
+async def test_execution_plans_validate_preserves_semantic_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 0, "from", "node"],
+        "message": "Source node 'missing' is not defined.",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["errors"][0]["phase"] == "semantic"
+    assert data["errors"][0]["path"] == ["edges", 0, "from", "node"]
+
+
+async def test_execution_plans_validate_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("workspace authorization failed")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["valid"] is None
+    assert data["errors"] == []
+    assert data["workspace_id"] == str(workspace_id)
+    assert "workspace authorization failed" in data["error"]
+
+
 def test_experimental_setting_reads_execution_plans_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -117,8 +288,15 @@ async def test_execution_plan_api_helper_uses_workspace_client(
     workspace_id: UUID,
     api_response: MagicMock,
 ) -> None:
-    route = "/flows/00000000-0000-0000-0000-000000000001/execution-plan/validate"
-    payload = {"schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION}
+    route = "/execution-plans/validate"
+    payload = {
+        "plan": {
+            "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+            "kind": "ExecutionPlan",
+            "nodes": {},
+            "edges": [],
+        }
+    }
 
     with patch(
         "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"


### PR DESCRIPTION
## Summary
- add `execution_plans_validate` behind the experimental execution-plan feature flag
- call the Cloud validation API at `POST /execution-plans/validate` with `{ "plan": ... }`
- preserve the Cloud validation response fields for repair-friendly agent output
- keep execution-plan MCP tools Cloud-only with workspace-scoped Prefect client calls and a structured disabled response when hidden
- update focused MCP tests for hidden direct-call behavior and validation responses

## Notes
- Stacked on #169.
- Invalid plan responses return `success: true` with `valid: false`; API/auth/workspace failures return `success: false` with `valid: null`.
