### PR TITLE
Add execution plan MCP read and publish tools

### DIFF
--- a/src/prefect_mcp_server/_prefect_client/execution_plans.py
+++ b/src/prefect_mcp_server/_prefect_client/execution_plans.py
@@ -6,6 +6,16 @@ from uuid import UUID
 from prefect_mcp_server._prefect_client.client import get_prefect_client
 
 ExecutionPlanApiMethod = Literal["GET", "POST", "PATCH", "DELETE"]
+PREFECT_CLOUD_WORKSPACE_API_HINT = (
+    "Execution plans are only available for Prefect Cloud workspaces. "
+    "Configure a Prefect Cloud workspace API URL or use Prefect Cloud OAuth "
+    "with an authorized workspace_id."
+)
+
+
+def is_cloud_workspace_api_url(api_url: str) -> bool:
+    """Return whether an API URL points at a Prefect Cloud workspace."""
+    return "/accounts/" in api_url and "/workspaces/" in api_url
 
 
 async def call_execution_plan_api(
@@ -18,14 +28,20 @@ async def call_execution_plan_api(
 ) -> Any:
     """Call a workspace-relative execution-plan Cloud API route.
 
-    The execution-plan MCP tools intentionally go through the same Prefect
-    client factory as existing tools so OAuth workspace consent, header auth,
-    environment credentials, and local profiles keep one shared boundary.
+    Execution plans are a Prefect Cloud-only surface. The tools still go
+    through the shared Prefect client factory so OAuth workspace consent,
+    Cloud header credentials, environment credentials, and local Cloud profiles
+    keep one auth boundary, but the resolved client must target a Cloud
+    workspace URL before any execution-plan request is sent.
     """
     if not path.startswith("/"):
         raise ValueError("Execution-plan API paths must start with '/'.")
 
     async with get_prefect_client(workspace_id=workspace_id) as client:
+        api_url = str(client.api_url)
+        if not is_cloud_workspace_api_url(api_url):
+            raise RuntimeError(PREFECT_CLOUD_WORKSPACE_API_HINT)
+
         response = await client.request(
             method,
             cast(Any, path),

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -1,11 +1,36 @@
 """Execution-plan authoring MCP namespace."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from pydantic import Field
+
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
+from prefect_mcp_server.types import (
+    ExecutionPlansValidateResult,
+    ExecutionPlanValidationError,
+)
+
+WorkspaceId = Annotated[
+    UUID,
+    Field(
+        description="Prefect Cloud workspace ID. Required when using Prefect Cloud OAuth mode.",
+    ),
+]
+ExecutionPlanDocument = Annotated[
+    dict[str, Any],
+    Field(
+        description=(
+            "Authored execution plan document to validate. The tool sends this "
+            "document to Prefect Cloud as {'plan': <document>}."
+        ),
+    ),
+]
 
 EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
-EXECUTION_PLAN_TOOL_NAMES: set[str] = set()
+EXECUTION_PLAN_TOOL_NAMES = {"execution_plans_validate"}
 EXECUTION_PLAN_API_BOUNDARY = (
     "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
     "through get_prefect_client(workspace_id=...)."
@@ -37,4 +62,40 @@ def execution_plans_disabled_response(
     }
 
 
-EXECUTION_PLAN_TOOLS = ()
+async def execution_plans_validate(
+    plan: ExecutionPlanDocument,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansValidateResult:
+    """Validate an authored execution-plan draft without saving a plan version."""
+    try:
+        response = await call_execution_plan_api(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": plan},
+        )
+    except Exception as exc:
+        return {
+            "success": False,
+            "valid": None,
+            "errors": [],
+            "workspace_id": str(workspace_id) if workspace_id else None,
+            "error": f"Failed to validate execution plan: {str(exc)}",
+        }
+
+    validation_response = cast(dict[str, Any], response)
+    validation_errors = cast(
+        list[ExecutionPlanValidationError],
+        validation_response.get("errors", []),
+    )
+
+    return {
+        "success": True,
+        "valid": cast(bool, validation_response["valid"]),
+        "errors": validation_errors,
+        "workspace_id": str(workspace_id) if workspace_id else None,
+        "error": None,
+    }
+
+
+EXECUTION_PLAN_TOOLS = (execution_plans_validate,)

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -4,33 +4,61 @@ from collections.abc import Mapping
 from typing import Annotated, Any, cast
 from uuid import UUID
 
+from httpx import HTTPStatusError
 from pydantic import Field
 
 from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
 from prefect_mcp_server.types import (
+    ExecutionPlanActiveState,
+    ExecutionPlansGetResult,
+    ExecutionPlansPublishResult,
     ExecutionPlansValidateResult,
     ExecutionPlanValidationError,
+    ExecutionPlanValidationPhase,
+    ExecutionPlanVersionInfo,
 )
 
+FlowId = Annotated[
+    UUID,
+    Field(
+        description="Prefect flow ID that owns the execution plan.",
+    ),
+]
 WorkspaceId = Annotated[
     UUID,
     Field(
         description="Prefect Cloud workspace ID. Required when using Prefect Cloud OAuth mode.",
     ),
 ]
+ExecutionPlanVersionId = Annotated[
+    UUID,
+    Field(
+        description="Execution-plan version ID. Omit to read the active version for the flow.",
+    ),
+]
 ExecutionPlanDocument = Annotated[
     dict[str, Any],
     Field(
         description=(
-            "Authored execution plan document to validate. The tool sends this "
+            "Authored execution plan document. The tool sends this "
             "document to Prefect Cloud as {'plan': <document>}."
         ),
+    ),
+]
+ExecutionPlanLayout = Annotated[
+    dict[str, Any],
+    Field(
+        description="Optional execution-plan layout metadata to persist with the version.",
     ),
 ]
 
 EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
-EXECUTION_PLAN_TOOL_NAMES = {"execution_plans_validate"}
+EXECUTION_PLAN_TOOL_NAMES = {
+    "execution_plans_validate",
+    "execution_plans_get",
+    "execution_plans_publish",
+}
 EXECUTION_PLAN_API_BOUNDARY = (
     "Execution-plan MCP tools are Cloud-only and use workspace-relative "
     "Prefect Cloud API routes through get_prefect_client(workspace_id=...)."
@@ -39,6 +67,89 @@ EXECUTION_PLAN_AUTH_CONTEXT = (
     "Uses Prefect Cloud OAuth workspace scoping, Cloud workspace API "
     "credentials from headers or environment, and local Cloud profile fallback."
 )
+EXECUTION_PLAN_VALIDATION_PHASES = {"document_shape", "semantic", "layout"}
+
+
+def _workspace_id(workspace_id: UUID | str | None) -> str | None:
+    return str(workspace_id) if workspace_id is not None else None
+
+
+def _version_id(version: ExecutionPlanVersionInfo | None) -> str | None:
+    if version is None:
+        return None
+
+    version_id = version.get("id")
+    return str(version_id) if version_id is not None else None
+
+
+async def _validate_execution_plan(
+    plan: dict[str, Any],
+    workspace_id: UUID | None,
+) -> tuple[bool, list[ExecutionPlanValidationError]]:
+    response = await call_execution_plan_api(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": plan},
+    )
+    validation_response = cast(dict[str, Any], response)
+    validation_errors = cast(
+        list[ExecutionPlanValidationError],
+        validation_response.get("errors", []),
+    )
+    return cast(bool, validation_response["valid"]), validation_errors
+
+
+def _publish_validation_errors(exc: Exception) -> list[ExecutionPlanValidationError]:
+    if not isinstance(exc, HTTPStatusError) or exc.response.status_code != 422:
+        return []
+
+    try:
+        payload = exc.response.json()
+    except ValueError:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+
+    detail = payload.get("detail")
+    if not isinstance(detail, list):
+        return []
+
+    validation_errors: list[ExecutionPlanValidationError] = []
+    for error in detail:
+        if not isinstance(error, dict):
+            continue
+
+        code = error.get("code") or error.get("type")
+        phase = error.get("phase") or "document_shape"
+        path = error.get("path", error.get("loc", []))
+        message = error.get("message") or error.get("msg")
+        if (
+            not isinstance(code, str)
+            or not isinstance(phase, str)
+            or phase not in EXECUTION_PLAN_VALIDATION_PHASES
+            or not isinstance(message, str)
+        ):
+            continue
+
+        if isinstance(path, tuple):
+            path = list(path)
+        elif not isinstance(path, list):
+            path = []
+
+        validation_errors.append(
+            {
+                "code": code,
+                "phase": cast(ExecutionPlanValidationPhase, phase),
+                "path": [
+                    path_part for path_part in path if isinstance(path_part, str | int)
+                ],
+                "message": message,
+            }
+        )
+
+    return validation_errors
 
 
 def execution_plans_disabled_response(
@@ -68,33 +179,217 @@ async def execution_plans_validate(
 ) -> ExecutionPlansValidateResult:
     """Validate an authored execution-plan draft without saving a plan version."""
     try:
-        response = await call_execution_plan_api(
-            "POST",
-            "/execution-plans/validate",
-            workspace_id=workspace_id,
-            json={"plan": plan},
-        )
+        valid, validation_errors = await _validate_execution_plan(plan, workspace_id)
     except Exception as exc:
         return {
             "success": False,
             "valid": None,
             "errors": [],
-            "workspace_id": str(workspace_id) if workspace_id else None,
+            "workspace_id": _workspace_id(workspace_id),
             "error": f"Failed to validate execution plan: {str(exc)}",
         }
 
-    validation_response = cast(dict[str, Any], response)
-    validation_errors = cast(
-        list[ExecutionPlanValidationError],
-        validation_response.get("errors", []),
-    )
-
     return {
         "success": True,
-        "valid": cast(bool, validation_response["valid"]),
+        "valid": valid,
         "errors": validation_errors,
-        "workspace_id": str(workspace_id) if workspace_id else None,
+        "workspace_id": _workspace_id(workspace_id),
         "error": None,
     }
 
-EXECUTION_PLAN_TOOLS = (execution_plans_validate,)
+
+async def execution_plans_get(
+    flow_id: FlowId,
+    version_id: ExecutionPlanVersionId | None = None,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansGetResult:
+    """Read the active execution plan for a flow or a specific plan version."""
+    source = "version" if version_id is not None else "active"
+
+    try:
+        if version_id is None:
+            response = await call_execution_plan_api(
+                "GET",
+                f"/flows/{flow_id}/execution-plan",
+                workspace_id=workspace_id,
+            )
+            if isinstance(response, dict) and "active_version" in response:
+                active_state = cast(ExecutionPlanActiveState, response)
+                version = active_state["active_version"]
+            elif isinstance(response, dict) and response.get("id") is not None:
+                version = cast(ExecutionPlanVersionInfo, response)
+            else:
+                version = None
+            active = version is not None
+        else:
+            response = await call_execution_plan_api(
+                "GET",
+                f"/flows/{flow_id}/execution-plan/versions/{version_id}",
+                workspace_id=workspace_id,
+            )
+            version = cast(ExecutionPlanVersionInfo, response)
+            active = None
+    except Exception as exc:
+        return {
+            "success": False,
+            "flow_id": str(flow_id),
+            "requested_version_id": str(version_id) if version_id else None,
+            "version_id": None,
+            "source": source,
+            "active": None,
+            "version": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to read execution plan: {str(exc)}",
+        }
+
+    return {
+        "success": True,
+        "flow_id": str(flow_id),
+        "requested_version_id": str(version_id) if version_id else None,
+        "version_id": _version_id(version),
+        "source": source,
+        "active": active,
+        "version": version,
+        "workspace_id": _workspace_id(workspace_id),
+        "error": None,
+    }
+
+
+async def execution_plans_publish(
+    flow_id: FlowId,
+    plan: ExecutionPlanDocument,
+    layout: ExecutionPlanLayout | None = None,
+    activate: Annotated[
+        bool,
+        Field(
+            description="Whether to activate the newly created version after publishing.",
+        ),
+    ] = True,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansPublishResult:
+    """Validate and publish an authored execution-plan draft as a new version."""
+    try:
+        # Cloud validates authored drafts through the workspace-scoped route;
+        # the flow-scoped create route below enforces persistence-specific checks.
+        valid, validation_errors = await _validate_execution_plan(plan, workspace_id)
+    except Exception as exc:
+        return {
+            "success": False,
+            "valid": None,
+            "errors": [],
+            "published": False,
+            "activated": False,
+            "flow_id": str(flow_id),
+            "version_id": None,
+            "created_version": None,
+            "active_state": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to validate execution plan before publishing: {str(exc)}",
+        }
+
+    if not valid:
+        return {
+            "success": True,
+            "valid": False,
+            "errors": validation_errors,
+            "published": False,
+            "activated": False,
+            "flow_id": str(flow_id),
+            "version_id": None,
+            "created_version": None,
+            "active_state": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": None,
+        }
+
+    create_body: dict[str, Any] = {"plan": plan}
+    if layout is not None:
+        create_body["layout"] = layout
+
+    try:
+        response = await call_execution_plan_api(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json=create_body,
+        )
+    except Exception as exc:
+        validation_errors = _publish_validation_errors(exc)
+        if validation_errors:
+            return {
+                "success": True,
+                "valid": False,
+                "errors": validation_errors,
+                "published": False,
+                "activated": False,
+                "flow_id": str(flow_id),
+                "version_id": None,
+                "created_version": None,
+                "active_state": None,
+                "workspace_id": _workspace_id(workspace_id),
+                "error": None,
+            }
+
+        return {
+            "success": False,
+            "valid": True,
+            "errors": [],
+            "published": False,
+            "activated": False,
+            "flow_id": str(flow_id),
+            "version_id": None,
+            "created_version": None,
+            "active_state": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to create execution plan version: {str(exc)}",
+        }
+
+    created_version = cast(ExecutionPlanVersionInfo, response)
+    created_version_id = _version_id(created_version)
+    active_state: ExecutionPlanActiveState | None = None
+    activated = False
+
+    if activate:
+        try:
+            response = await call_execution_plan_api(
+                "POST",
+                f"/flows/{flow_id}/execution-plan/versions/{created_version_id}/activate",
+                workspace_id=workspace_id,
+            )
+        except Exception as exc:
+            return {
+                "success": False,
+                "valid": True,
+                "errors": [],
+                "published": True,
+                "activated": False,
+                "flow_id": str(flow_id),
+                "version_id": created_version_id,
+                "created_version": created_version,
+                "active_state": None,
+                "workspace_id": _workspace_id(workspace_id),
+                "error": f"Failed to activate execution plan version: {str(exc)}",
+            }
+
+        active_state = cast(ExecutionPlanActiveState, response)
+        activated = True
+
+    return {
+        "success": True,
+        "valid": True,
+        "errors": [],
+        "published": True,
+        "activated": activated,
+        "flow_id": str(flow_id),
+        "version_id": created_version_id,
+        "created_version": created_version,
+        "active_state": active_state,
+        "workspace_id": _workspace_id(workspace_id),
+        "error": None,
+    }
+
+EXECUTION_PLAN_TOOLS = (
+    execution_plans_validate,
+    execution_plans_get,
+    execution_plans_publish,
+)

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -32,12 +32,12 @@ EXECUTION_PLANS_NAMESPACE = "execution_plans"
 EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
 EXECUTION_PLAN_TOOL_NAMES = {"execution_plans_validate"}
 EXECUTION_PLAN_API_BOUNDARY = (
-    "Execution-plan MCP tools use workspace-relative Prefect Cloud API routes "
-    "through get_prefect_client(workspace_id=...)."
+    "Execution-plan MCP tools are Cloud-only and use workspace-relative "
+    "Prefect Cloud API routes through get_prefect_client(workspace_id=...)."
 )
 EXECUTION_PLAN_AUTH_CONTEXT = (
-    "Uses existing Prefect MCP auth, workspace scoping, OAuth consent, header "
-    "credentials, and local profile fallback."
+    "Uses Prefect Cloud OAuth workspace scoping, Cloud workspace API "
+    "credentials from headers or environment, and local Cloud profile fallback."
 )
 
 
@@ -57,7 +57,7 @@ def execution_plans_disabled_response(
         "error": (
             "Execution-plan authoring is disabled for this MCP server. "
             "Set PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true to enable the "
-            "execution_plans namespace."
+            "Cloud-only execution_plans namespace."
         ),
     }
 
@@ -96,6 +96,5 @@ async def execution_plans_validate(
         "workspace_id": str(workspace_id) if workspace_id else None,
         "error": None,
     }
-
 
 EXECUTION_PLAN_TOOLS = (execution_plans_validate,)

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -56,7 +56,9 @@ WorkspaceId = Annotated[
 def orientation() -> str:
     """Use this tool to get oriented with the Prefect MCP server."""
     return """
-    This is a read-only server. For mutations, use the CLI.
+    Default Prefect inspection tools are read-only. For ordinary mutations, use the CLI.
+
+    If experimental execution-plan authoring is enabled, execution_plans_publish can create and activate execution-plan versions and requires credentials with those write permissions.
 
     Use the attached docs MCP server to search for documentation on Prefect concepts, usage examples, and best practices.
 

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 from typing_extensions import NotRequired, TypedDict
@@ -534,4 +534,23 @@ class RateLimitsResult(TypedDict):
     until: str | None
     summary: RateLimitSummary | None
     throttling_periods: list[ThrottlingPeriod] | None
+    error: str | None
+
+
+class ExecutionPlanValidationError(TypedDict):
+    """Validation issue returned by the Prefect Cloud execution-plan API."""
+
+    code: str
+    phase: Literal["document_shape", "semantic"]
+    path: list[str | int]
+    message: str
+
+
+class ExecutionPlansValidateResult(TypedDict):
+    """Result of validating an authored execution-plan document."""
+
+    success: bool
+    valid: bool | None
+    errors: list[ExecutionPlanValidationError]
+    workspace_id: str | None
     error: str | None

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -537,11 +537,14 @@ class RateLimitsResult(TypedDict):
     error: str | None
 
 
+ExecutionPlanValidationPhase = Literal["document_shape", "semantic", "layout"]
+
+
 class ExecutionPlanValidationError(TypedDict):
     """Validation issue returned by the Prefect Cloud execution-plan API."""
 
     code: str
-    phase: Literal["document_shape", "semantic"]
+    phase: ExecutionPlanValidationPhase
     path: list[str | int]
     message: str
 
@@ -552,5 +555,56 @@ class ExecutionPlansValidateResult(TypedDict):
     success: bool
     valid: bool | None
     errors: list[ExecutionPlanValidationError]
+    workspace_id: str | None
+    error: str | None
+
+
+class ExecutionPlanVersionInfo(TypedDict, total=False):
+    """Execution-plan version details returned by Prefect Cloud."""
+
+    id: str
+    flow_id: str
+    schema_version: str
+    semantic_hash: str
+    created: str
+    created_by: dict[str, Any] | None
+    activated: str | None
+    activated_by: dict[str, Any] | None
+    plan: dict[str, Any]
+    layout: dict[str, Any] | None
+
+
+class ExecutionPlanActiveState(TypedDict):
+    """Active execution-plan state returned by Prefect Cloud."""
+
+    active_version: ExecutionPlanVersionInfo | None
+
+
+class ExecutionPlansGetResult(TypedDict):
+    """Result of reading an execution-plan version through MCP."""
+
+    success: bool
+    flow_id: str
+    requested_version_id: str | None
+    version_id: str | None
+    source: Literal["active", "version"]
+    active: bool | None
+    version: ExecutionPlanVersionInfo | None
+    workspace_id: str | None
+    error: str | None
+
+
+class ExecutionPlansPublishResult(TypedDict):
+    """Result of validating and publishing an authored execution-plan draft."""
+
+    success: bool
+    valid: bool | None
+    errors: list[ExecutionPlanValidationError]
+    published: bool
+    activated: bool
+    flow_id: str
+    version_id: str | None
+    created_version: ExecutionPlanVersionInfo | None
+    active_state: ExecutionPlanActiveState | None
     workspace_id: str | None
     error: str | None

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -1,16 +1,17 @@
 """Tests for execution-plan MCP authoring surface."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from uuid import UUID
 
 import pytest
 from fastmcp import Client
+from httpx import HTTPStatusError, Request, Response
 
 from prefect_mcp_server import execution_plans
 from prefect_mcp_server import server as server_module
 from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
-from prefect_mcp_server.server import build_prefect_mcp_server
+from prefect_mcp_server.server import build_prefect_mcp_server, orientation
 from prefect_mcp_server.settings import ExperimentalSettings, settings
 
 
@@ -18,6 +19,18 @@ from prefect_mcp_server.settings import ExperimentalSettings, settings
 def workspace_id() -> UUID:
     """Return a workspace ID for execution-plan authoring tests."""
     return UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.fixture
+def flow_id() -> UUID:
+    """Return a flow ID for execution-plan authoring tests."""
+    return UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+@pytest.fixture
+def version_id() -> UUID:
+    """Return an execution-plan version ID for authoring tests."""
+    return UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 
 @pytest.fixture
@@ -58,6 +71,37 @@ def valid_execution_plan() -> dict[str, Any]:
         "kind": "ExecutionPlan",
         "nodes": {},
         "edges": [],
+    }
+
+
+@pytest.fixture
+def execution_plan_version(
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a persisted execution-plan version API payload."""
+    return {
+        "id": str(version_id),
+        "flow_id": str(flow_id),
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "semantic_hash": "sha256:abc123",
+        "created": "2026-06-24T12:00:00Z",
+        "created_by": {"id": "user-1", "type": "USER"},
+        "plan": valid_execution_plan,
+        "layout": {"nodes": {"classify_ticket": {"x": 0, "y": 0}}},
+    }
+
+
+@pytest.fixture
+def active_execution_plan_version(
+    execution_plan_version: dict[str, Any],
+) -> dict[str, Any]:
+    """Return an active execution-plan version API payload."""
+    return {
+        **execution_plan_version,
+        "activated": "2026-06-24T12:01:00Z",
+        "activated_by": {"id": "user-2", "type": "USER"},
     }
 
 
@@ -220,6 +264,412 @@ async def test_execution_plans_validate_surfaces_api_errors(
     assert data["errors"] == []
     assert data["workspace_id"] == str(workspace_id)
     assert "workspace authorization failed" in data["error"]
+
+async def test_execution_plans_get_reads_active_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    active_execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"active_version": active_execution_plan_version}),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["source"] == "active"
+    assert data["active"] is True
+    assert data["flow_id"] == str(flow_id)
+    assert data["requested_version_id"] is None
+    assert data["version_id"] == str(version_id)
+    assert data["version"] == active_execution_plan_version
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        f"/flows/{flow_id}/execution-plan",
+        workspace_id=workspace_id,
+    )
+
+
+async def test_execution_plans_get_reads_empty_active_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"active_version": None}),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["source"] == "active"
+    assert data["active"] is False
+    assert data["flow_id"] == str(flow_id)
+    assert data["requested_version_id"] is None
+    assert data["version_id"] is None
+    assert data["version"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        f"/flows/{flow_id}/execution-plan",
+        workspace_id=workspace_id,
+    )
+
+
+async def test_execution_plans_get_reads_specific_version(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=execution_plan_version),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "version_id": str(version_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["source"] == "version"
+    assert data["active"] is None
+    assert data["flow_id"] == str(flow_id)
+    assert data["requested_version_id"] == str(version_id)
+    assert data["version_id"] == str(version_id)
+    assert data["version"] == execution_plan_version
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        f"/flows/{flow_id}/execution-plan/versions/{version_id}",
+        workspace_id=workspace_id,
+    )
+
+
+async def test_execution_plans_get_surfaces_workspace_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("workspace authorization failed")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["source"] == "active"
+    assert data["active"] is None
+    assert data["flow_id"] == str(flow_id)
+    assert data["version_id"] is None
+    assert data["version"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert "workspace authorization failed" in data["error"]
+
+
+async def test_execution_plans_publish_inactive_validates_then_creates_version(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+    execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    layout = {"nodes": {"classify_ticket": {"x": 10, "y": 20}}}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                {"valid": True, "errors": []},
+                execution_plan_version,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                    "layout": layout,
+                    "activate": False,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is True
+    assert data["errors"] == []
+    assert data["published"] is True
+    assert data["activated"] is False
+    assert data["flow_id"] == str(flow_id)
+    assert data["version_id"] == str(version_id)
+    assert data["created_version"] == execution_plan_version
+    assert data["active_state"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan, "layout": layout},
+        ),
+    ]
+
+
+async def test_execution_plans_publish_active_validates_creates_and_activates(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+    execution_plan_version: dict[str, Any],
+    active_execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    active_state = {"active_version": active_execution_plan_version}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                {"valid": True, "errors": []},
+                execution_plan_version,
+                active_state,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is True
+    assert data["published"] is True
+    assert data["activated"] is True
+    assert data["version_id"] == str(version_id)
+    assert data["created_version"] == execution_plan_version
+    assert data["active_state"] == active_state
+    assert data["error"] is None
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions/{version_id}/activate",
+            workspace_id=workspace_id,
+        ),
+    ]
+
+
+async def test_execution_plans_publish_validation_failure_skips_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 0, "from", "node"],
+        "message": "Source node 'missing' is not defined.",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["published"] is False
+    assert data["activated"] is False
+    assert data["version_id"] is None
+    assert data["created_version"] is None
+    assert data["active_state"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": valid_execution_plan},
+    )
+
+
+async def test_execution_plans_publish_preserves_create_validation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "invalid_layout",
+        "phase": "layout",
+        "path": ["layout"],
+        "message": "Layout must be an object.",
+    }
+    request = Request(
+        "POST",
+        f"https://api.prefect.cloud/flows/{flow_id}/execution-plan/versions",
+    )
+    response = Response(
+        422,
+        request=request,
+        json={"detail": [validation_error]},
+    )
+    exc = HTTPStatusError(
+        "Unprocessable Entity",
+        request=request,
+        response=response,
+    )
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                {"valid": True, "errors": []},
+                exc,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                    "layout": {"nodes": []},
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["published"] is False
+    assert data["activated"] is False
+    assert data["version_id"] is None
+    assert data["created_version"] is None
+    assert data["active_state"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan, "layout": {"nodes": []}},
+        ),
+    ]
+
+
+def test_orientation_documents_execution_plan_publish_write_exception() -> None:
+    oriented_text = orientation()
+
+    assert "Default Prefect inspection tools are read-only" in oriented_text
+    assert "execution_plans_publish" in oriented_text
+    assert "requires credentials with those write permissions" in oriented_text
 
 
 def test_experimental_setting_reads_execution_plans_env_var(

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -83,6 +83,7 @@ async def test_execution_plans_tools_report_disabled_when_hidden(
     assert data["namespace"] == "execution_plans"
     assert data["workspace_id"] == str(workspace_id)
     assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+    assert "Cloud-only execution_plans namespace" in data["error"]
 
 
 async def test_execution_plans_validate_returns_valid_plan_result(
@@ -302,6 +303,9 @@ async def test_execution_plan_api_helper_uses_workspace_client(
         "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
     ) as mock_get_client:
         mock_client = AsyncMock()
+        mock_client.api_url = (
+            "https://api.prefect.cloud/api/accounts/test/workspaces/test"
+        )
         mock_client.request = AsyncMock(return_value=api_response)
         mock_get_client.return_value.__aenter__.return_value = mock_client
 
@@ -321,3 +325,21 @@ async def test_execution_plan_api_helper_uses_workspace_client(
         params=None,
     )
     api_response.raise_for_status.assert_called_once()
+
+
+async def test_execution_plan_api_helper_rejects_non_cloud_workspace_client(
+    api_response: MagicMock,
+) -> None:
+    with patch(
+        "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.api_url = "http://localhost:4200/api"
+        mock_client.request = AsyncMock(return_value=api_response)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="only available for Prefect Cloud"):
+            await call_execution_plan_api("POST", "/execution-plans/validate")
+
+    mock_get_client.assert_called_once_with(workspace_id=None)
+    mock_client.request.assert_not_awaited()

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -50,6 +50,177 @@ def registered_execution_plan_test_tool(monkeypatch: pytest.MonkeyPatch) -> str:
     return tool_name
 
 
+@pytest.fixture
+def valid_execution_plan() -> dict[str, Any]:
+    """Return a valid authored execution-plan document."""
+    return {
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "kind": "ExecutionPlan",
+        "nodes": {},
+        "edges": [],
+    }
+
+
+async def test_execution_plans_tools_report_disabled_when_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tool_names = {tool.name for tool in await client.list_tools()}
+        result = await client.call_tool(
+            "execution_plans_validate",
+            {"workspace_id": str(workspace_id)},
+        )
+
+    assert "execution_plans_validate" not in tool_names
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["enabled"] is False
+    assert data["namespace"] == "execution_plans"
+    assert data["workspace_id"] == str(workspace_id)
+    assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+
+
+async def test_execution_plans_validate_returns_valid_plan_result(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    api_result = {"valid": True, "errors": []}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=api_result),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {
+        "success": True,
+        "valid": True,
+        "errors": [],
+        "workspace_id": str(workspace_id),
+        "error": None,
+    }
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": valid_execution_plan},
+    )
+
+
+async def test_execution_plans_validate_preserves_schema_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_required_field",
+        "phase": "document_shape",
+        "path": ["nodes", "draft"],
+        "message": "Field required",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["error"] is None
+
+
+async def test_execution_plans_validate_preserves_semantic_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 0, "from", "node"],
+        "message": "Source node 'missing' is not defined.",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["errors"][0]["phase"] == "semantic"
+    assert data["errors"][0]["path"] == ["edges", 0, "from", "node"]
+
+
+async def test_execution_plans_validate_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("workspace authorization failed")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["valid"] is None
+    assert data["errors"] == []
+    assert data["workspace_id"] == str(workspace_id)
+    assert "workspace authorization failed" in data["error"]
+
+
 def test_experimental_setting_reads_execution_plans_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -117,8 +288,15 @@ async def test_execution_plan_api_helper_uses_workspace_client(
     workspace_id: UUID,
     api_response: MagicMock,
 ) -> None:
-    route = "/flows/00000000-0000-0000-0000-000000000001/execution-plan/validate"
-    payload = {"schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION}
+    route = "/execution-plans/validate"
+    payload = {
+        "plan": {
+            "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+            "kind": "ExecutionPlan",
+            "nodes": {},
+            "edges": [],
+        }
+    }
 
     with patch(
         "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"


### PR DESCRIPTION
## Summary

- Add `execution_plans_get` for active execution-plan reads and specific version reads.
- Add `execution_plans_publish` for validated draft publishing with optional activation and stable follow-up identifiers.
- Surface publish-time 422 details as repair-friendly errors.

## Notes

Stacked on #171.