### PR TITLE
Bump beta release manifest to 0.0.1-beta.12

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.PrefectHQ/prefect-mcp-server",
   "title": "Prefect MCP Server",
   "description": "MCP server for Prefect. Monitor and debug workflows, deployments, and automations.",
-  "version": "0.0.1-beta.11",
+  "version": "0.0.1-beta.12",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "prefect-mcp",
-      "version": "0.0.1-beta.11",
+      "version": "0.0.1-beta.12",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Bump the MCP registry/package manifest to `0.0.1-beta.12` so we can cut the next beta patch containing the hosted Cloud OAuth and service-account MCP updates.

## Details

- updates `server.json` top-level version
- updates the packaged `prefect-mcp` version in `server.json`
- validated both values match the intended tag
