### PR TITLE
Add execution plan MCP authoring tools

### DIFF
--- a/src/prefect_mcp_server/_prefect_client/__init__.py
+++ b/src/prefect_mcp_server/_prefect_client/__init__.py
@@ -5,6 +5,7 @@ from prefect_mcp_server._prefect_client.client import get_prefect_client
 from prefect_mcp_server._prefect_client.dashboard import fetch_dashboard
 from prefect_mcp_server._prefect_client.deployments import get_deployments
 from prefect_mcp_server._prefect_client.events import fetch_events
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
 from prefect_mcp_server._prefect_client.flow_runs import (
     get_flow_run,
     get_flow_run_logs,
@@ -19,6 +20,7 @@ from prefect_mcp_server._prefect_client.work_pools import get_work_pool, get_wor
 __all__ = [
     "fetch_dashboard",
     "fetch_events",
+    "call_execution_plan_api",
     "get_automations",
     "get_deployments",
     "get_flow_run",

--- a/src/prefect_mcp_server/_prefect_client/execution_plans.py
+++ b/src/prefect_mcp_server/_prefect_client/execution_plans.py
@@ -1,0 +1,54 @@
+"""Execution-plan Cloud API boundary for Prefect MCP tools."""
+
+from typing import Any, Literal, cast
+from uuid import UUID
+
+from prefect_mcp_server._prefect_client.client import get_prefect_client
+
+ExecutionPlanApiMethod = Literal["GET", "POST", "PATCH", "DELETE"]
+PREFECT_CLOUD_WORKSPACE_API_HINT = (
+    "Execution plans are only available for Prefect Cloud workspaces. "
+    "Configure a Prefect Cloud workspace API URL or use Prefect Cloud OAuth "
+    "with an authorized workspace_id."
+)
+
+
+def is_cloud_workspace_api_url(api_url: str) -> bool:
+    """Return whether an API URL points at a Prefect Cloud workspace."""
+    return "/accounts/" in api_url and "/workspaces/" in api_url
+
+
+async def call_execution_plan_api(
+    method: ExecutionPlanApiMethod,
+    path: str,
+    *,
+    workspace_id: UUID | None = None,
+    json: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """Call a workspace-relative execution-plan Cloud API route.
+
+    Execution plans are a Prefect Cloud-only surface. The tools still go
+    through the shared Prefect client factory so OAuth workspace consent,
+    Cloud header credentials, environment credentials, and local Cloud profiles
+    keep one auth boundary, but the resolved client must target a Cloud
+    workspace URL before any execution-plan request is sent.
+    """
+    if not path.startswith("/"):
+        raise ValueError("Execution-plan API paths must start with '/'.")
+
+    async with get_prefect_client(workspace_id=workspace_id) as client:
+        api_url = str(client.api_url)
+        if not is_cloud_workspace_api_url(api_url):
+            raise RuntimeError(PREFECT_CLOUD_WORKSPACE_API_HINT)
+
+        response = await client.request(
+            method,
+            cast(Any, path),
+            json=json,
+            params=params,
+        )
+        response.raise_for_status()
+        if not response.content:
+            return None
+        return response.json()

--- a/src/prefect_mcp_server/execution_plans.py
+++ b/src/prefect_mcp_server/execution_plans.py
@@ -1,0 +1,458 @@
+"""Execution-plan authoring MCP namespace."""
+
+from collections.abc import Mapping
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from httpx import HTTPStatusError
+from pydantic import Field
+
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
+from prefect_mcp_server.types import (
+    ExecutionPlanActiveState,
+    ExecutionPlansGetResult,
+    ExecutionPlansGetSchemaResult,
+    ExecutionPlansPublishResult,
+    ExecutionPlansValidateResult,
+    ExecutionPlanValidationError,
+    ExecutionPlanValidationPhase,
+    ExecutionPlanVersionInfo,
+)
+
+FlowId = Annotated[
+    UUID,
+    Field(
+        description="Prefect flow ID that owns the execution plan.",
+    ),
+]
+WorkspaceId = Annotated[
+    UUID,
+    Field(
+        description="Prefect Cloud workspace ID. Required when using Prefect Cloud OAuth mode.",
+    ),
+]
+ExecutionPlanVersionId = Annotated[
+    UUID,
+    Field(
+        description="Execution-plan version ID. Omit to read the active version for the flow.",
+    ),
+]
+ExecutionPlanDocument = Annotated[
+    dict[str, Any],
+    Field(
+        description=(
+            "Authored execution plan document. The tool sends this "
+            "document to Prefect Cloud as {'plan': <document>}."
+        ),
+    ),
+]
+ExecutionPlanLayout = Annotated[
+    dict[str, Any],
+    Field(
+        description="Optional execution-plan layout metadata to persist with the version.",
+    ),
+]
+ExecutionPlanSchemaVersion = Annotated[
+    str,
+    Field(
+        description=(
+            "Authored execution-plan schema version to retrieve. Omit to use "
+            "Prefect Cloud's current schema version."
+        ),
+    ),
+]
+
+EXECUTION_PLANS_NAMESPACE = "execution_plans"
+EXECUTION_PLAN_SCHEMA_VERSION = "0.1"
+EXECUTION_PLAN_TOOL_NAMES = {
+    "execution_plans_get_schema",
+    "execution_plans_validate",
+    "execution_plans_get",
+    "execution_plans_publish",
+}
+EXECUTION_PLAN_API_BOUNDARY = (
+    "Execution-plan MCP tools are Cloud-only and use workspace-relative "
+    "Prefect Cloud API routes through get_prefect_client(workspace_id=...)."
+)
+EXECUTION_PLAN_AUTH_CONTEXT = (
+    "Uses Prefect Cloud OAuth workspace scoping, Cloud workspace API "
+    "credentials from headers or environment, and local Cloud profile fallback."
+)
+EXECUTION_PLAN_VALIDATION_PHASES = {"document_shape", "semantic", "layout"}
+
+
+def _workspace_id(workspace_id: UUID | str | None) -> str | None:
+    return str(workspace_id) if workspace_id is not None else None
+
+
+def _version_id(version: ExecutionPlanVersionInfo | None) -> str | None:
+    if version is None:
+        return None
+
+    version_id = version.get("id")
+    return str(version_id) if version_id is not None else None
+
+
+async def _validate_execution_plan(
+    plan: dict[str, Any],
+    workspace_id: UUID | None,
+) -> tuple[bool, list[ExecutionPlanValidationError]]:
+    response = await call_execution_plan_api(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": plan},
+    )
+    validation_response = cast(dict[str, Any], response)
+    validation_errors = cast(
+        list[ExecutionPlanValidationError],
+        validation_response.get("errors", []),
+    )
+    return cast(bool, validation_response["valid"]), validation_errors
+
+
+def _publish_validation_errors(exc: Exception) -> list[ExecutionPlanValidationError]:
+    if not isinstance(exc, HTTPStatusError) or exc.response.status_code != 422:
+        return []
+
+    try:
+        payload = exc.response.json()
+    except ValueError:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+
+    detail = payload.get("detail")
+    if not isinstance(detail, list):
+        return []
+
+    validation_errors: list[ExecutionPlanValidationError] = []
+    for error in detail:
+        if not isinstance(error, dict):
+            continue
+
+        code = error.get("code") or error.get("type")
+        phase = error.get("phase") or "document_shape"
+        path = error.get("path", error.get("loc", []))
+        message = error.get("message") or error.get("msg")
+        if (
+            not isinstance(code, str)
+            or not isinstance(phase, str)
+            or phase not in EXECUTION_PLAN_VALIDATION_PHASES
+            or not isinstance(message, str)
+        ):
+            continue
+
+        if isinstance(path, tuple):
+            path = list(path)
+        elif not isinstance(path, list):
+            path = []
+
+        validation_errors.append(
+            {
+                "code": code,
+                "phase": cast(ExecutionPlanValidationPhase, phase),
+                "path": [
+                    path_part for path_part in path if isinstance(path_part, str | int)
+                ],
+                "message": message,
+            }
+        )
+
+    return validation_errors
+
+
+def execution_plans_disabled_response(
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return an agent-readable disabled response for the execution-plan surface."""
+    workspace_id = arguments.get("workspace_id")
+    return {
+        "success": False,
+        "enabled": False,
+        "namespace": EXECUTION_PLANS_NAMESPACE,
+        "schema_version": EXECUTION_PLAN_SCHEMA_VERSION,
+        "workspace_id": str(workspace_id) if workspace_id else None,
+        "api_boundary": EXECUTION_PLAN_API_BOUNDARY,
+        "auth_context": EXECUTION_PLAN_AUTH_CONTEXT,
+        "error": (
+            "Execution-plan authoring is disabled for this MCP server. "
+            "Set PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true to enable the "
+            "Cloud-only execution_plans namespace."
+        ),
+    }
+
+
+async def execution_plans_validate(
+    plan: ExecutionPlanDocument,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansValidateResult:
+    """Validate an authored execution-plan draft without saving a plan version."""
+    try:
+        valid, validation_errors = await _validate_execution_plan(plan, workspace_id)
+    except Exception as exc:
+        return {
+            "success": False,
+            "valid": None,
+            "errors": [],
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to validate execution plan: {str(exc)}",
+        }
+
+    return {
+        "success": True,
+        "valid": valid,
+        "errors": validation_errors,
+        "workspace_id": _workspace_id(workspace_id),
+        "error": None,
+    }
+
+
+async def execution_plans_get_schema(
+    version: ExecutionPlanSchemaVersion | None = None,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansGetSchemaResult:
+    """Read authored execution-plan schema metadata from Prefect Cloud."""
+    try:
+        response = await call_execution_plan_api(
+            "GET",
+            "/execution-plans/schema",
+            workspace_id=workspace_id,
+            params={"version": version} if version is not None else None,
+        )
+        schema_response = cast(dict[str, Any], response)
+        supported_schema_versions = cast(
+            list[str],
+            schema_response["supported_schema_versions"],
+        )
+
+        return {
+            "success": True,
+            "schema_version": cast(str, schema_response["schema_version"]),
+            "schema": cast(dict[str, Any], schema_response["schema"]),
+            "supported_schema_versions": supported_schema_versions,
+            "current_schema_version": cast(
+                str,
+                schema_response["current_schema_version"],
+            ),
+            "is_current": cast(bool, schema_response["is_current"]),
+            "is_deprecated": cast(bool, schema_response["is_deprecated"]),
+            "document_shape_only": cast(bool, schema_response["document_shape_only"]),
+            "validation_guidance": cast(str, schema_response["validation_guidance"]),
+            "workspace_id": _workspace_id(workspace_id),
+            "error": None,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "schema_version": version,
+            "schema": None,
+            "supported_schema_versions": [],
+            "current_schema_version": None,
+            "is_current": None,
+            "is_deprecated": None,
+            "document_shape_only": None,
+            "validation_guidance": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to read execution plan schema: {str(exc)}",
+        }
+
+
+async def execution_plans_get(
+    flow_id: FlowId,
+    version_id: ExecutionPlanVersionId | None = None,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansGetResult:
+    """Read the active execution plan for a flow or a specific plan version."""
+    source = "version" if version_id is not None else "active"
+
+    try:
+        if version_id is None:
+            response = await call_execution_plan_api(
+                "GET",
+                f"/flows/{flow_id}/execution-plan",
+                workspace_id=workspace_id,
+            )
+            if isinstance(response, dict) and "active_version" in response:
+                active_state = cast(ExecutionPlanActiveState, response)
+                version = active_state["active_version"]
+            elif isinstance(response, dict) and response.get("id") is not None:
+                version = cast(ExecutionPlanVersionInfo, response)
+            else:
+                version = None
+            active = version is not None
+        else:
+            response = await call_execution_plan_api(
+                "GET",
+                f"/flows/{flow_id}/execution-plan/versions/{version_id}",
+                workspace_id=workspace_id,
+            )
+            version = cast(ExecutionPlanVersionInfo, response)
+            active = None
+    except Exception as exc:
+        return {
+            "success": False,
+            "flow_id": str(flow_id),
+            "requested_version_id": str(version_id) if version_id else None,
+            "version_id": None,
+            "source": source,
+            "active": None,
+            "version": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to read execution plan: {str(exc)}",
+        }
+
+    return {
+        "success": True,
+        "flow_id": str(flow_id),
+        "requested_version_id": str(version_id) if version_id else None,
+        "version_id": _version_id(version),
+        "source": source,
+        "active": active,
+        "version": version,
+        "workspace_id": _workspace_id(workspace_id),
+        "error": None,
+    }
+
+
+async def execution_plans_publish(
+    flow_id: FlowId,
+    plan: ExecutionPlanDocument,
+    layout: ExecutionPlanLayout | None = None,
+    activate: Annotated[
+        bool,
+        Field(
+            description="Whether to activate the newly created version after publishing.",
+        ),
+    ] = True,
+    workspace_id: WorkspaceId | None = None,
+) -> ExecutionPlansPublishResult:
+    """Validate and publish an authored execution-plan draft as a new version."""
+    try:
+        # Cloud validates authored drafts through the workspace-scoped route;
+        # the flow-scoped create route below enforces persistence-specific checks.
+        valid, validation_errors = await _validate_execution_plan(plan, workspace_id)
+    except Exception as exc:
+        return {
+            "success": False,
+            "valid": None,
+            "errors": [],
+            "published": False,
+            "activated": False,
+            "flow_id": str(flow_id),
+            "version_id": None,
+            "created_version": None,
+            "active_state": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to validate execution plan before publishing: {str(exc)}",
+        }
+
+    if not valid:
+        return {
+            "success": True,
+            "valid": False,
+            "errors": validation_errors,
+            "published": False,
+            "activated": False,
+            "flow_id": str(flow_id),
+            "version_id": None,
+            "created_version": None,
+            "active_state": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": None,
+        }
+
+    create_body: dict[str, Any] = {"plan": plan}
+    if layout is not None:
+        create_body["layout"] = layout
+
+    try:
+        response = await call_execution_plan_api(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json=create_body,
+        )
+    except Exception as exc:
+        validation_errors = _publish_validation_errors(exc)
+        if validation_errors:
+            return {
+                "success": True,
+                "valid": False,
+                "errors": validation_errors,
+                "published": False,
+                "activated": False,
+                "flow_id": str(flow_id),
+                "version_id": None,
+                "created_version": None,
+                "active_state": None,
+                "workspace_id": _workspace_id(workspace_id),
+                "error": None,
+            }
+
+        return {
+            "success": False,
+            "valid": True,
+            "errors": [],
+            "published": False,
+            "activated": False,
+            "flow_id": str(flow_id),
+            "version_id": None,
+            "created_version": None,
+            "active_state": None,
+            "workspace_id": _workspace_id(workspace_id),
+            "error": f"Failed to create execution plan version: {str(exc)}",
+        }
+
+    created_version = cast(ExecutionPlanVersionInfo, response)
+    created_version_id = _version_id(created_version)
+    active_state: ExecutionPlanActiveState | None = None
+    activated = False
+
+    if activate:
+        try:
+            response = await call_execution_plan_api(
+                "POST",
+                f"/flows/{flow_id}/execution-plan/versions/{created_version_id}/activate",
+                workspace_id=workspace_id,
+            )
+        except Exception as exc:
+            return {
+                "success": False,
+                "valid": True,
+                "errors": [],
+                "published": True,
+                "activated": False,
+                "flow_id": str(flow_id),
+                "version_id": created_version_id,
+                "created_version": created_version,
+                "active_state": None,
+                "workspace_id": _workspace_id(workspace_id),
+                "error": f"Failed to activate execution plan version: {str(exc)}",
+            }
+
+        active_state = cast(ExecutionPlanActiveState, response)
+        activated = True
+
+    return {
+        "success": True,
+        "valid": True,
+        "errors": [],
+        "published": True,
+        "activated": activated,
+        "flow_id": str(flow_id),
+        "version_id": created_version_id,
+        "created_version": created_version,
+        "active_state": active_state,
+        "workspace_id": _workspace_id(workspace_id),
+        "error": None,
+    }
+
+
+EXECUTION_PLAN_TOOLS = (
+    execution_plans_get_schema,
+    execution_plans_validate,
+    execution_plans_get,
+    execution_plans_publish,
+)

--- a/src/prefect_mcp_server/middleware.py
+++ b/src/prefect_mcp_server/middleware.py
@@ -1,13 +1,68 @@
 """middleware for prefect mcp server."""
 
 import logging
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import mcp.types as mt
 from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import Tool, ToolResult
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FeatureFlag:
+    """Configuration for one feature-gated tool namespace."""
+
+    enabled: Callable[[], bool]
+    tool_names: frozenset[str]
+    disabled_response: Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+class FeatureFlagMiddleware(Middleware):
+    """Return feature-specific disabled responses for gated tools."""
+
+    def __init__(self, features: Sequence[FeatureFlag]) -> None:
+        self._features = tuple(features)
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, Any],
+    ) -> Any:
+        """Short-circuit calls to known tools for disabled features."""
+        tool_name = context.message.name
+        arguments = context.message.arguments or {}
+
+        for feature in self._features:
+            if tool_name in feature.tool_names and not feature.enabled():
+                return ToolResult(
+                    structured_content=feature.disabled_response(arguments)
+                )
+
+        return await call_next(context)
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        """Hide tools for disabled features from tool discovery."""
+        tools = await call_next(context)
+        disabled_tool_names = {
+            tool_name
+            for feature in self._features
+            if not feature.enabled()
+            for tool_name in feature.tool_names
+        }
+
+        if not disabled_tool_names:
+            return tools
+
+        return [tool for tool in tools if tool.name not in disabled_tool_names]
 
 
 class PrefectAuthMiddleware(Middleware):

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -12,8 +12,12 @@ from fastmcp.server.providers.proxy import ProxyClient
 from prefect.client.base import ServerType, determine_server_type
 from pydantic import Field
 
-from prefect_mcp_server import _prefect_client, cloud_oauth
-from prefect_mcp_server.middleware import PrefectAuthMiddleware
+from prefect_mcp_server import _prefect_client, cloud_oauth, execution_plans
+from prefect_mcp_server.middleware import (
+    FeatureFlag,
+    FeatureFlagMiddleware,
+    PrefectAuthMiddleware,
+)
 from prefect_mcp_server.settings import settings
 from prefect_mcp_server.types import (
     AutomationsResult,
@@ -52,7 +56,9 @@ WorkspaceId = Annotated[
 def orientation() -> str:
     """Use this tool to get oriented with the Prefect MCP server."""
     return """
-    This is a read-only server. For mutations, use the CLI.
+    Default Prefect inspection tools are read-only. For ordinary mutations, use the CLI.
+
+    If experimental execution-plan authoring is enabled, execution_plans_get_schema can retrieve the Cloud-authored document schema, and execution_plans_publish can create and activate execution-plan versions with credentials that have those write permissions.
 
     Use the attached docs MCP server to search for documentation on Prefect concepts, usage examples, and best practices.
 
@@ -545,6 +551,7 @@ CORE_TOOLS = (
 
 CLOUD_TOOLS = (review_rate_limits,)
 CLOUD_OAUTH_TOOLS = (list_authorized_workspaces,)
+EXECUTION_PLAN_TOOLS = execution_plans.EXECUTION_PLAN_TOOLS
 
 
 def build_prefect_mcp_server(
@@ -558,6 +565,17 @@ def build_prefect_mcp_server(
     """Build a Prefect MCP server from shared tools and optional Cloud adapters."""
     server = FastMCP(name, auth=auth_provider)
     server.add_middleware(PrefectAuthMiddleware())
+    server.add_middleware(
+        FeatureFlagMiddleware(
+            features=(
+                FeatureFlag(
+                    enabled=lambda: settings.experimental.execution_plans_enabled,
+                    tool_names=frozenset(execution_plans.EXECUTION_PLAN_TOOL_NAMES),
+                    disabled_response=execution_plans.execution_plans_disabled_response,
+                ),
+            )
+        )
+    )
 
     if include_docs_proxy:
         docs_proxy = create_proxy(
@@ -584,6 +602,9 @@ def build_prefect_mcp_server(
     if include_cloud_oauth_tools:
         for tool in CLOUD_OAUTH_TOOLS:
             server.add_tool(tool)
+
+    for tool in EXECUTION_PLAN_TOOLS:
+        server.add_tool(tool)
 
     return server
 

--- a/src/prefect_mcp_server/settings.py
+++ b/src/prefect_mcp_server/settings.py
@@ -48,6 +48,21 @@ class LogfireSettings(BaseSettings):
     )
 
 
+class ExperimentalSettings(BaseSettings):
+    """Experimental MCP feature settings."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_MCP_EXPERIMENTAL_",
+        extra="ignore",
+        env_file=".env",
+    )
+
+    execution_plans_enabled: bool = Field(
+        default=False,
+        description="Whether to enable the experimental execution-plan authoring MCP surface",
+    )
+
+
 class Settings(BaseSettings):
     """Settings for the Prefect MCP server."""
 
@@ -66,6 +81,11 @@ class Settings(BaseSettings):
     logfire: LogfireSettings = Field(
         default_factory=LogfireSettings,
         description="Logfire settings",
+    )
+
+    experimental: ExperimentalSettings = Field(
+        default_factory=ExperimentalSettings,
+        description="Experimental MCP feature settings",
     )
 
 

--- a/src/prefect_mcp_server/types.py
+++ b/src/prefect_mcp_server/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 from typing_extensions import NotRequired, TypedDict
@@ -535,4 +535,93 @@ class RateLimitsResult(TypedDict):
     until: str | None
     summary: RateLimitSummary | None
     throttling_periods: list[ThrottlingPeriod] | None
+    error: str | None
+
+
+ExecutionPlanValidationPhase = Literal["document_shape", "semantic", "layout"]
+
+
+class ExecutionPlanValidationError(TypedDict):
+    """Validation issue returned by the Prefect Cloud execution-plan API."""
+
+    code: str
+    phase: ExecutionPlanValidationPhase
+    path: list[str | int]
+    message: str
+
+
+class ExecutionPlansValidateResult(TypedDict):
+    """Result of validating an authored execution-plan document."""
+
+    success: bool
+    valid: bool | None
+    errors: list[ExecutionPlanValidationError]
+    workspace_id: str | None
+    error: str | None
+
+
+class ExecutionPlansGetSchemaResult(TypedDict):
+    """Result of reading authored execution-plan schema metadata through MCP."""
+
+    success: bool
+    schema_version: str | None
+    schema: dict[str, Any] | None
+    supported_schema_versions: list[str]
+    current_schema_version: str | None
+    is_current: bool | None
+    is_deprecated: bool | None
+    document_shape_only: bool | None
+    validation_guidance: str | None
+    workspace_id: str | None
+    error: str | None
+
+
+class ExecutionPlanVersionInfo(TypedDict, total=False):
+    """Execution-plan version details returned by Prefect Cloud."""
+
+    id: str
+    flow_id: str
+    schema_version: str
+    semantic_hash: str
+    created: str
+    created_by: dict[str, Any] | None
+    activated: str | None
+    activated_by: dict[str, Any] | None
+    plan: dict[str, Any]
+    layout: dict[str, Any] | None
+
+
+class ExecutionPlanActiveState(TypedDict):
+    """Active execution-plan state returned by Prefect Cloud."""
+
+    active_version: ExecutionPlanVersionInfo | None
+
+
+class ExecutionPlansGetResult(TypedDict):
+    """Result of reading an execution-plan version through MCP."""
+
+    success: bool
+    flow_id: str
+    requested_version_id: str | None
+    version_id: str | None
+    source: Literal["active", "version"]
+    active: bool | None
+    version: ExecutionPlanVersionInfo | None
+    workspace_id: str | None
+    error: str | None
+
+
+class ExecutionPlansPublishResult(TypedDict):
+    """Result of validating and publishing an authored execution-plan draft."""
+
+    success: bool
+    valid: bool | None
+    errors: list[ExecutionPlanValidationError]
+    published: bool
+    activated: bool
+    flow_id: str
+    version_id: str | None
+    created_version: ExecutionPlanVersionInfo | None
+    active_state: ExecutionPlanActiveState | None
+    workspace_id: str | None
     error: str | None

--- a/tests/fixtures/execution_plan_authoring_loop_reference.json
+++ b/tests/fixtures/execution_plan_authoring_loop_reference.json
@@ -1,0 +1,38 @@
+{
+  "tools": [
+    "execution_plans_get_schema",
+    "execution_plans_validate",
+    "execution_plans_get",
+    "execution_plans_publish"
+  ],
+  "schema_result": {
+    "schema_version": "0.1",
+    "current_schema_version": "0.1",
+    "document_shape_only": true,
+    "is_current": true
+  },
+  "validation_failure": {
+    "success": true,
+    "valid": false,
+    "errors": [
+      {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 1, "from", "node"],
+        "message": "Source node 'missing_research' is not defined."
+      }
+    ],
+    "workspace_id": "12345678-1234-5678-1234-567812345678",
+    "error": null
+  },
+  "publish_result": {
+    "success": true,
+    "valid": true,
+    "published": true,
+    "activated": true
+  },
+  "read_back": {
+    "source": "active",
+    "active": true
+  }
+}

--- a/tests/test_execution_plans.py
+++ b/tests/test_execution_plans.py
@@ -1,0 +1,1161 @@
+"""Tests for execution-plan MCP authoring surface."""
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+from uuid import UUID
+
+import pytest
+from fastmcp import Client
+from httpx import HTTPStatusError, Request, Response
+
+from prefect_mcp_server import execution_plans
+from prefect_mcp_server import server as server_module
+from prefect_mcp_server._prefect_client.execution_plans import call_execution_plan_api
+from prefect_mcp_server.server import build_prefect_mcp_server, orientation
+from prefect_mcp_server.settings import ExperimentalSettings, settings
+
+
+@pytest.fixture
+def workspace_id() -> UUID:
+    """Return a workspace ID for execution-plan authoring tests."""
+    return UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.fixture
+def flow_id() -> UUID:
+    """Return a flow ID for execution-plan authoring tests."""
+    return UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+@pytest.fixture
+def version_id() -> UUID:
+    """Return an execution-plan version ID for authoring tests."""
+    return UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+@pytest.fixture
+def api_response() -> MagicMock:
+    """Return a JSON HTTP response for execution-plan helper tests."""
+    response = MagicMock()
+    response.content = b'{"ok": true}'
+    response.json.return_value = {"ok": True}
+    response.raise_for_status.return_value = None
+    return response
+
+
+async def execution_plans_test_tool(
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the provided workspace ID from a feature-gated test tool."""
+    return {"success": True, "workspace_id": workspace_id}
+
+
+@pytest.fixture
+def registered_execution_plan_test_tool(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Register a temporary execution-plan tool through the server registry."""
+    tool_name = "execution_plans_test_tool"
+    monkeypatch.setattr(execution_plans, "EXECUTION_PLAN_TOOL_NAMES", {tool_name})
+    monkeypatch.setattr(
+        server_module,
+        "EXECUTION_PLAN_TOOLS",
+        (execution_plans_test_tool,),
+    )
+    return tool_name
+
+
+@pytest.fixture
+def valid_execution_plan() -> dict[str, Any]:
+    """Return a valid authored execution-plan document."""
+    return {
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "kind": "ExecutionPlan",
+        "nodes": {},
+        "edges": [],
+    }
+
+
+@pytest.fixture
+def execution_plan_version(
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a persisted execution-plan version API payload."""
+    return {
+        "id": str(version_id),
+        "flow_id": str(flow_id),
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "semantic_hash": "sha256:abc123",
+        "created": "2026-06-24T12:00:00Z",
+        "created_by": {"id": "user-1", "type": "USER"},
+        "plan": valid_execution_plan,
+        "layout": {"nodes": {"classify_ticket": {"x": 0, "y": 0}}},
+    }
+
+
+@pytest.fixture
+def active_execution_plan_version(
+    execution_plan_version: dict[str, Any],
+) -> dict[str, Any]:
+    """Return an active execution-plan version API payload."""
+    return {
+        **execution_plan_version,
+        "activated": "2026-06-24T12:01:00Z",
+        "activated_by": {"id": "user-2", "type": "USER"},
+    }
+
+
+@pytest.fixture
+def execution_plan_schema_response() -> dict[str, Any]:
+    """Return an authored execution-plan schema API payload."""
+    return {
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "schema": {
+            "title": "AuthoredExecutionPlanV0_1",
+            "type": "object",
+            "properties": {
+                "schema_version": {
+                    "const": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION
+                },
+                "kind": {"const": "ExecutionPlan"},
+                "nodes": {"type": "object"},
+                "edges": {"type": "array"},
+            },
+            "required": ["schema_version", "kind", "nodes", "edges"],
+        },
+        "supported_schema_versions": [execution_plans.EXECUTION_PLAN_SCHEMA_VERSION],
+        "current_schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "is_current": True,
+        "is_deprecated": False,
+        "document_shape_only": True,
+        "validation_guidance": (
+            "This JSON Schema describes document shape only. Call "
+            "POST /execution-plans/validate before publishing a draft because "
+            "semantic validation may still reject schema-valid documents."
+        ),
+    }
+
+
+async def test_execution_plans_tools_report_disabled_when_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tool_names = {tool.name for tool in await client.list_tools()}
+        result = await client.call_tool(
+            "execution_plans_validate",
+            {"workspace_id": str(workspace_id)},
+        )
+
+    assert execution_plans.EXECUTION_PLAN_TOOL_NAMES.isdisjoint(tool_names)
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["enabled"] is False
+    assert data["namespace"] == "execution_plans"
+    assert data["workspace_id"] == str(workspace_id)
+    assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+    assert "Cloud-only execution_plans namespace" in data["error"]
+
+
+async def test_execution_plans_get_schema_returns_schema_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    execution_plan_schema_response: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=execution_plan_schema_response),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get_schema",
+                {
+                    "workspace_id": str(workspace_id),
+                    "version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {
+        "success": True,
+        "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "schema": execution_plan_schema_response["schema"],
+        "supported_schema_versions": [execution_plans.EXECUTION_PLAN_SCHEMA_VERSION],
+        "current_schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+        "is_current": True,
+        "is_deprecated": False,
+        "document_shape_only": True,
+        "validation_guidance": execution_plan_schema_response["validation_guidance"],
+        "workspace_id": str(workspace_id),
+        "error": None,
+    }
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        "/execution-plans/schema",
+        workspace_id=workspace_id,
+        params={"version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION},
+    )
+
+
+async def test_execution_plans_get_schema_defaults_to_cloud_current_version(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    execution_plan_schema_response: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=execution_plan_schema_response),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get_schema",
+                {"workspace_id": str(workspace_id)},
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["schema_version"] == execution_plans.EXECUTION_PLAN_SCHEMA_VERSION
+    assert data["schema"] == execution_plan_schema_response["schema"]
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        "/execution-plans/schema",
+        workspace_id=workspace_id,
+        params=None,
+    )
+
+
+async def test_execution_plans_get_schema_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("schema version not found")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get_schema",
+                {
+                    "workspace_id": str(workspace_id),
+                    "version": "0.2",
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["schema_version"] == "0.2"
+    assert data["schema"] is None
+    assert data["supported_schema_versions"] == []
+    assert data["current_schema_version"] is None
+    assert data["is_current"] is None
+    assert data["is_deprecated"] is None
+    assert data["document_shape_only"] is None
+    assert data["validation_guidance"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert "schema version not found" in data["error"]
+
+
+async def test_execution_plans_validate_returns_valid_plan_result(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    api_result = {"valid": True, "errors": []}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=api_result),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {
+        "success": True,
+        "valid": True,
+        "errors": [],
+        "workspace_id": str(workspace_id),
+        "error": None,
+    }
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": valid_execution_plan},
+    )
+
+
+async def test_execution_plans_validate_preserves_schema_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_required_field",
+        "phase": "document_shape",
+        "path": ["nodes", "draft"],
+        "message": "Field required",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["error"] is None
+
+
+async def test_execution_plans_validate_preserves_semantic_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 0, "from", "node"],
+        "message": "Source node 'missing' is not defined.",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["errors"][0]["phase"] == "semantic"
+    assert data["errors"][0]["path"] == ["edges", 0, "from", "node"]
+
+
+async def test_execution_plans_validate_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("workspace authorization failed")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["valid"] is None
+    assert data["errors"] == []
+    assert data["workspace_id"] == str(workspace_id)
+    assert "workspace authorization failed" in data["error"]
+
+
+async def test_execution_plans_get_reads_active_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    active_execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"active_version": active_execution_plan_version}),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["source"] == "active"
+    assert data["active"] is True
+    assert data["flow_id"] == str(flow_id)
+    assert data["requested_version_id"] is None
+    assert data["version_id"] == str(version_id)
+    assert data["version"] == active_execution_plan_version
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        f"/flows/{flow_id}/execution-plan",
+        workspace_id=workspace_id,
+    )
+
+
+async def test_execution_plans_get_reads_empty_active_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"active_version": None}),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["source"] == "active"
+    assert data["active"] is False
+    assert data["flow_id"] == str(flow_id)
+    assert data["requested_version_id"] is None
+    assert data["version_id"] is None
+    assert data["version"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        f"/flows/{flow_id}/execution-plan",
+        workspace_id=workspace_id,
+    )
+
+
+async def test_execution_plans_get_reads_specific_version(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value=execution_plan_version),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "version_id": str(version_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["source"] == "version"
+    assert data["active"] is None
+    assert data["flow_id"] == str(flow_id)
+    assert data["requested_version_id"] == str(version_id)
+    assert data["version_id"] == str(version_id)
+    assert data["version"] == execution_plan_version
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "GET",
+        f"/flows/{flow_id}/execution-plan/versions/{version_id}",
+        workspace_id=workspace_id,
+    )
+
+
+async def test_execution_plans_get_surfaces_workspace_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(side_effect=RuntimeError("workspace authorization failed")),
+    ):
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["source"] == "active"
+    assert data["active"] is None
+    assert data["flow_id"] == str(flow_id)
+    assert data["version_id"] is None
+    assert data["version"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert "workspace authorization failed" in data["error"]
+
+
+async def test_execution_plans_publish_inactive_validates_then_creates_version(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+    execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    layout = {"nodes": {"classify_ticket": {"x": 10, "y": 20}}}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                {"valid": True, "errors": []},
+                execution_plan_version,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                    "layout": layout,
+                    "activate": False,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is True
+    assert data["errors"] == []
+    assert data["published"] is True
+    assert data["activated"] is False
+    assert data["flow_id"] == str(flow_id)
+    assert data["version_id"] == str(version_id)
+    assert data["created_version"] == execution_plan_version
+    assert data["active_state"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan, "layout": layout},
+        ),
+    ]
+
+
+async def test_execution_plans_publish_active_validates_creates_and_activates(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+    execution_plan_version: dict[str, Any],
+    active_execution_plan_version: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    active_state = {"active_version": active_execution_plan_version}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                {"valid": True, "errors": []},
+                execution_plan_version,
+                active_state,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is True
+    assert data["published"] is True
+    assert data["activated"] is True
+    assert data["version_id"] == str(version_id)
+    assert data["created_version"] == execution_plan_version
+    assert data["active_state"] == active_state
+    assert data["error"] is None
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions/{version_id}/activate",
+            workspace_id=workspace_id,
+        ),
+    ]
+
+
+async def test_execution_plans_publish_validation_failure_skips_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 0, "from", "node"],
+        "message": "Source node 'missing' is not defined.",
+    }
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(return_value={"valid": False, "errors": [validation_error]}),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["published"] is False
+    assert data["activated"] is False
+    assert data["version_id"] is None
+    assert data["created_version"] is None
+    assert data["active_state"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    mock_call_execution_plan_api.assert_awaited_once_with(
+        "POST",
+        "/execution-plans/validate",
+        workspace_id=workspace_id,
+        json={"plan": valid_execution_plan},
+    )
+
+
+async def test_execution_plans_publish_preserves_create_validation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    valid_execution_plan: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    validation_error = {
+        "code": "invalid_layout",
+        "phase": "layout",
+        "path": ["layout"],
+        "message": "Layout must be an object.",
+    }
+    request = Request(
+        "POST",
+        f"https://api.prefect.cloud/flows/{flow_id}/execution-plan/versions",
+    )
+    response = Response(
+        422,
+        request=request,
+        json={"detail": [validation_error]},
+    )
+    exc = HTTPStatusError(
+        "Unprocessable Entity",
+        request=request,
+        response=response,
+    )
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                {"valid": True, "errors": []},
+                exc,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                    "layout": {"nodes": []},
+                },
+            )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is True
+    assert data["valid"] is False
+    assert data["errors"] == [validation_error]
+    assert data["published"] is False
+    assert data["activated"] is False
+    assert data["version_id"] is None
+    assert data["created_version"] is None
+    assert data["active_state"] is None
+    assert data["workspace_id"] == str(workspace_id)
+    assert data["error"] is None
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan, "layout": {"nodes": []}},
+        ),
+    ]
+
+
+async def test_execution_plans_authoring_loop_validates_repairs_publishes_and_reads_back(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_id: UUID,
+    flow_id: UUID,
+    version_id: UUID,
+    valid_execution_plan: dict[str, Any],
+    execution_plan_version: dict[str, Any],
+    active_execution_plan_version: dict[str, Any],
+    execution_plan_schema_response: dict[str, Any],
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+    reference_path = (
+        Path(__file__).parent
+        / "fixtures"
+        / "execution_plan_authoring_loop_reference.json"
+    )
+    reference = json.loads(reference_path.read_text())
+    invalid_plan = deepcopy(valid_execution_plan)
+    invalid_plan["edges"] = [
+        {
+            "id": "input_to_research",
+            "from": {"type": "plan_input", "input": "question"},
+            "to": {"node": "research", "input": "question"},
+        },
+        {
+            "id": "missing_research_to_summary",
+            "from": {
+                "type": "node_output",
+                "node": "missing_research",
+                "output": "findings",
+            },
+            "to": {"node": "summarize", "input": "findings"},
+        },
+    ]
+    validation_error: dict[str, Any] = {
+        "code": "missing_source_node",
+        "phase": "semantic",
+        "path": ["edges", 1, "from", "node"],
+        "message": "Source node 'missing_research' is not defined.",
+    }
+    active_state = {"active_version": active_execution_plan_version}
+
+    with patch(
+        "prefect_mcp_server.execution_plans.call_execution_plan_api",
+        new=AsyncMock(
+            side_effect=[
+                execution_plan_schema_response,
+                {"valid": False, "errors": [validation_error]},
+                {"valid": True, "errors": []},
+                {"valid": True, "errors": []},
+                execution_plan_version,
+                active_state,
+                active_state,
+            ]
+        ),
+    ) as mock_call_execution_plan_api:
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            schema_result = await client.call_tool(
+                "execution_plans_get_schema",
+                {"workspace_id": str(workspace_id)},
+            )
+            invalid_validation_result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": invalid_plan,
+                },
+            )
+            repaired_validation_result = await client.call_tool(
+                "execution_plans_validate",
+                {
+                    "workspace_id": str(workspace_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+            publish_result = await client.call_tool(
+                "execution_plans_publish",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                    "plan": valid_execution_plan,
+                },
+            )
+            get_result = await client.call_tool(
+                "execution_plans_get",
+                {
+                    "workspace_id": str(workspace_id),
+                    "flow_id": str(flow_id),
+                },
+            )
+
+    tool_names = {tool.name for tool in tools}
+    execution_plan_tool_names = {
+        name for name in tool_names if name.startswith("execution_plans_")
+    }
+    execution_tool_schema_text = json.dumps(
+        [
+            tool.model_dump(mode="json")
+            for tool in tools
+            if tool.name in execution_plan_tool_names
+        ],
+        sort_keys=True,
+    ).lower()
+
+    assert set(reference["tools"]) == execution_plans.EXECUTION_PLAN_TOOL_NAMES
+    assert len(json.dumps(reference)) < 1300
+    assert execution_plan_tool_names == execution_plans.EXECUTION_PLAN_TOOL_NAMES
+    assert "execution_plans_activate" not in execution_plan_tool_names
+    assert "execution_plans_create_version" not in execution_plan_tool_names
+    assert "execution_plans_run" not in execution_plan_tool_names
+    assert "execution_plans_schedule" not in execution_plan_tool_names
+    assert "schedule" not in execution_tool_schema_text
+    assert "storage" not in execution_tool_schema_text
+
+    schema_data = (
+        schema_result.structured_content.get("result")
+        or schema_result.structured_content
+    )
+    invalid_validation_data = (
+        invalid_validation_result.structured_content.get("result")
+        or invalid_validation_result.structured_content
+    )
+    repaired_validation_data = (
+        repaired_validation_result.structured_content.get("result")
+        or repaired_validation_result.structured_content
+    )
+    publish_data = (
+        publish_result.structured_content.get("result")
+        or publish_result.structured_content
+    )
+    get_data = (
+        get_result.structured_content.get("result") or get_result.structured_content
+    )
+
+    assert schema_data["success"] is True
+    assert {
+        "schema_version": schema_data["schema_version"],
+        "current_schema_version": schema_data["current_schema_version"],
+        "document_shape_only": schema_data["document_shape_only"],
+        "is_current": schema_data["is_current"],
+    } == reference["schema_result"]
+    assert schema_data["schema"] == execution_plan_schema_response["schema"]
+    assert "POST /execution-plans/validate" in schema_data["validation_guidance"]
+    assert invalid_validation_data == reference["validation_failure"]
+    assert invalid_validation_data["errors"][0]["code"] == "missing_source_node"
+    assert invalid_validation_data["errors"][0]["phase"] == "semantic"
+    assert invalid_validation_data["errors"][0]["path"] == [
+        "edges",
+        1,
+        "from",
+        "node",
+    ]
+    assert "missing_research" in invalid_validation_data["errors"][0]["message"]
+    assert repaired_validation_data["success"] is True
+    assert repaired_validation_data["valid"] is True
+    assert repaired_validation_data["errors"] == []
+    assert publish_data["success"] is True
+    assert publish_data["valid"] is True
+    assert publish_data["published"] is True
+    assert publish_data["activated"] is True
+    assert {
+        "success": publish_data["success"],
+        "valid": publish_data["valid"],
+        "published": publish_data["published"],
+        "activated": publish_data["activated"],
+    } == reference["publish_result"]
+    assert publish_data["version_id"] == str(version_id)
+    assert publish_data["created_version"]["plan"] == valid_execution_plan
+    assert get_data["success"] is True
+    assert get_data["source"] == "active"
+    assert get_data["active"] is True
+    assert {
+        "source": get_data["source"],
+        "active": get_data["active"],
+    } == reference["read_back"]
+    assert get_data["version_id"] == str(version_id)
+    assert get_data["version"]["plan"] == valid_execution_plan
+    assert mock_call_execution_plan_api.await_args_list == [
+        call(
+            "GET",
+            "/execution-plans/schema",
+            workspace_id=workspace_id,
+            params=None,
+        ),
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": invalid_plan},
+        ),
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            "/execution-plans/validate",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions",
+            workspace_id=workspace_id,
+            json={"plan": valid_execution_plan},
+        ),
+        call(
+            "POST",
+            f"/flows/{flow_id}/execution-plan/versions/{version_id}/activate",
+            workspace_id=workspace_id,
+        ),
+        call(
+            "GET",
+            f"/flows/{flow_id}/execution-plan",
+            workspace_id=workspace_id,
+        ),
+    ]
+
+
+def test_orientation_documents_execution_plan_publish_write_exception() -> None:
+    oriented_text = orientation()
+
+    assert "Default Prefect inspection tools are read-only" in oriented_text
+    assert "execution_plans_get_schema" in oriented_text
+    assert "execution_plans_publish" in oriented_text
+    assert "credentials that have those write permissions" in oriented_text
+
+
+def test_experimental_setting_reads_execution_plans_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED", "true")
+
+    assert ExperimentalSettings().execution_plans_enabled is True
+
+
+async def test_disabled_execution_plan_tools_are_hidden_from_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_execution_plan_test_tool: str,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+
+    assert registered_execution_plan_test_tool not in {tool.name for tool in tools}
+
+
+async def test_disabled_execution_plan_direct_call_returns_structured_response(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_execution_plan_test_tool: str,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            registered_execution_plan_test_tool,
+            {"workspace_id": str(workspace_id)},
+        )
+
+    data = result.structured_content.get("result") or result.structured_content
+    assert data["success"] is False
+    assert data["enabled"] is False
+    assert data["namespace"] == execution_plans.EXECUTION_PLANS_NAMESPACE
+    assert data["workspace_id"] == str(workspace_id)
+    assert "PREFECT_MCP_EXPERIMENTAL_EXECUTION_PLANS_ENABLED=true" in data["error"]
+
+
+async def test_enabled_execution_plan_tools_are_discoverable_and_callable(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_execution_plan_test_tool: str,
+    workspace_id: UUID,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", True)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        result = await client.call_tool(
+            registered_execution_plan_test_tool,
+            {"workspace_id": str(workspace_id)},
+        )
+
+    assert registered_execution_plan_test_tool in {tool.name for tool in tools}
+    data = result.structured_content.get("result") or result.structured_content
+    assert data == {"success": True, "workspace_id": str(workspace_id)}
+
+
+async def test_execution_plan_api_helper_uses_workspace_client(
+    workspace_id: UUID,
+    api_response: MagicMock,
+) -> None:
+    route = "/execution-plans/validate"
+    payload = {
+        "plan": {
+            "schema_version": execution_plans.EXECUTION_PLAN_SCHEMA_VERSION,
+            "kind": "ExecutionPlan",
+            "nodes": {},
+            "edges": [],
+        }
+    }
+
+    with patch(
+        "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.api_url = (
+            "https://api.prefect.cloud/api/accounts/test/workspaces/test"
+        )
+        mock_client.request = AsyncMock(return_value=api_response)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        result = await call_execution_plan_api(
+            "POST",
+            route,
+            workspace_id=workspace_id,
+            json=payload,
+        )
+
+    assert result == {"ok": True}
+    mock_get_client.assert_called_once_with(workspace_id=workspace_id)
+    mock_client.request.assert_awaited_once_with(
+        "POST",
+        route,
+        json=payload,
+        params=None,
+    )
+    api_response.raise_for_status.assert_called_once()
+
+
+async def test_execution_plan_api_helper_rejects_non_cloud_workspace_client(
+    api_response: MagicMock,
+) -> None:
+    with patch(
+        "prefect_mcp_server._prefect_client.execution_plans.get_prefect_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.api_url = "http://localhost:4200/api"
+        mock_client.request = AsyncMock(return_value=api_response)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="only available for Prefect Cloud"):
+            await call_execution_plan_api("POST", "/execution-plans/validate")
+
+    mock_get_client.assert_called_once_with(workspace_id=None)
+    mock_client.request.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add an experimental execution-plan MCP namespace with feature-gated discovery and structured disabled responses
- add Cloud-only schema discovery, validation, read, and publish tools backed by workspace-scoped Prefect API calls
- add behavior-focused tests for gating, Cloud boundary checks, schema metadata, validation responses, publishing, reads, and the end-to-end authoring loop
