### PR TITLE
Use Cloud JWKS for hosted OAuth token verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ The token response includes `expires_in`. Treat an agent as long-running if it m
 Prefect-operated Cloud OAuth deployments use a dedicated entrypoint:
 
 - server path: `src/prefect_mcp_server/cloud.py`
-- required runtime secret: `PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY`
+- required runtime flag: `PREFECT_MCP_CLOUD_ENABLED=true`
 
 This entrypoint reuses the same read-only tool definitions as the local/API-key server, adds Prefect Cloud OAuth, and adds Cloud OAuth-only workspace discovery. If OAuth is not configured, the Cloud OAuth entrypoint fails at import time instead of starting an unprotected server.
 
-Cloud OAuth mode is selected by deploying `src/prefect_mcp_server/cloud.py`. The token key is the required runtime secret for validating Prefect Cloud-issued MCP OAuth access tokens; it is not a user-provided Prefect API key.
+Cloud OAuth mode is selected by deploying `src/prefect_mcp_server/cloud.py`. The hosted server validates Prefect Cloud-issued MCP OAuth access tokens against Prefect Cloud's JWKS endpoint, so the MCP runtime does not need access to Cloud token-signing secrets.
 
 <details>
 <summary>Cloud OAuth configuration reference</summary>
@@ -163,10 +163,12 @@ Cloud OAuth settings use the `PREFECT_MCP_CLOUD_` prefix:
 
 | Environment variable | Purpose |
 | --- | --- |
-| `PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY` | Required signing/verification key for Prefect Cloud issued MCP OAuth access tokens |
+| `PREFECT_MCP_CLOUD_ENABLED` | Set to `true` for hosted Cloud OAuth mode |
 | `PREFECT_MCP_CLOUD_API_BASE_URL` | Optional override for the Prefect API base URL |
 | `PREFECT_MCP_CLOUD_AUTH_BASE_URL` | Optional override for auth helper endpoints |
+| `PREFECT_MCP_CLOUD_AUTH_JWKS_URI` | Optional override for the Prefect Cloud MCP OAuth JWKS endpoint |
 | `PREFECT_MCP_CLOUD_AUTHORIZATION_SERVER` | Optional override for advertised OAuth authorization server |
+| `PREFECT_MCP_CLOUD_AUTH_AUDIENCE` | Optional override for the expected token audience; defaults to the hosted MCP public URL |
 | `PREFECT_MCP_CLOUD_CLIENT_ID` | Optional service-account MCP OAuth client id for unattended token exchange |
 | `PREFECT_MCP_CLOUD_CLIENT_SECRET` | Optional service-account MCP OAuth client secret for unattended token exchange |
 | `PREFECT_MCP_CLOUD_PUBLIC_BASE_URL` | Public base URL for the hosted MCP server |

--- a/src/prefect_mcp_server/cloud_oauth.py
+++ b/src/prefect_mcp_server/cloud_oauth.py
@@ -41,7 +41,9 @@ class CloudOAuthSettings(BaseSettings):
         extra="ignore",
     )
 
+    enabled: bool = Field(default=False)
     auth_token_key: str | None = Field(default=None)
+    auth_jwks_uri: str | None = Field(default=None)
     environment: CloudEnvironment = Field(default="prod")
     public_base_url: str = Field(
         default_factory=lambda: os.environ.get(
@@ -53,14 +55,10 @@ class CloudOAuthSettings(BaseSettings):
     auth_base_url: str | None = Field(default=None)
     authorization_server: str | None = Field(default=None)
     auth_issuer: str = Field(default="AuthServerID")
-    auth_audience: str = Field(default="AuthServerID")
-    auth_algorithm: str = Field(default="HS256")
+    auth_audience: str | None = Field(default=None)
+    auth_algorithm: str | None = Field(default=None)
     client_id: str | None = Field(default=None)
     client_secret: str | None = Field(default=None)
-
-    @property
-    def enabled(self) -> bool:
-        return self.auth_token_key is not None
 
     @property
     def resolved_api_base_url(self) -> str:
@@ -81,6 +79,28 @@ class CloudOAuthSettings(BaseSettings):
     @property
     def resolved_public_base_url(self) -> str:
         return self.public_base_url.rstrip("/")
+
+    @property
+    def resolved_auth_jwks_uri(self) -> str:
+        if self.auth_jwks_uri:
+            return self.auth_jwks_uri
+        return f"{self.resolved_auth_base_url}/auth/mcp/oauth/jwks.json"
+
+    @property
+    def resolved_auth_audience(self) -> str:
+        if self.auth_audience:
+            return self.auth_audience.rstrip("/")
+        if self.auth_token_key:
+            return "AuthServerID"
+        return self.resolved_public_base_url
+
+    @property
+    def resolved_auth_algorithm(self) -> str:
+        if self.auth_algorithm:
+            return self.auth_algorithm
+        if self.auth_token_key:
+            return "HS256"
+        return "RS256"
 
 
 @dataclass(frozen=True)
@@ -167,24 +187,31 @@ class PrefectCloudRemoteAuthProvider(RemoteAuthProvider):
 
 def build_auth_provider(*, require_enabled: bool = False) -> RemoteAuthProvider | None:
     """Build the FastMCP auth provider when Cloud OAuth is configured."""
-    if not settings.enabled:
+    if not settings.enabled and settings.auth_token_key is None:
         if require_enabled:
             raise RuntimeError(
-                "Prefect Cloud OAuth mode requires PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY."
+                "Prefect Cloud OAuth mode requires PREFECT_MCP_CLOUD_ENABLED=true."
             )
         return None
 
-    if settings.auth_token_key is None:
-        raise RuntimeError("Cloud OAuth token key was not configured.")
-
-    token_verifier = JWTVerifier(
-        public_key=settings.auth_token_key,
-        issuer=settings.auth_issuer,
-        audience=settings.auth_audience,
-        algorithm=settings.auth_algorithm,
-        required_scopes=["prefect-cloud:workspaces"],
-        base_url=settings.resolved_public_base_url,
-    )
+    if settings.auth_token_key is not None:
+        token_verifier = JWTVerifier(
+            public_key=settings.auth_token_key,
+            issuer=settings.auth_issuer,
+            audience=settings.resolved_auth_audience,
+            algorithm=settings.resolved_auth_algorithm,
+            required_scopes=["prefect-cloud:workspaces"],
+            base_url=settings.resolved_public_base_url,
+        )
+    else:
+        token_verifier = JWTVerifier(
+            jwks_uri=settings.resolved_auth_jwks_uri,
+            issuer=settings.auth_issuer,
+            audience=settings.resolved_auth_audience,
+            algorithm=settings.resolved_auth_algorithm,
+            required_scopes=["prefect-cloud:workspaces"],
+            base_url=settings.resolved_public_base_url,
+        )
     return PrefectCloudRemoteAuthProvider(
         token_verifier=token_verifier,
         authorization_servers=[AnyHttpUrl(settings.resolved_authorization_server)],

--- a/tests/test_cloud_oauth.py
+++ b/tests/test_cloud_oauth.py
@@ -83,11 +83,7 @@ async def test_get_prefect_client_requires_workspace_in_oauth_mode() -> None:
             "prefect_mcp_server._prefect_client.client.cloud_oauth.current_oauth_access_token",
             return_value="oauth-token",
         ),
-        patch(
-            "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.enabled",
-            new_callable=PropertyMock,
-            return_value=True,
-        ),
+        patch.object(cloud_oauth.settings, "enabled", True),
     ):
         with pytest.raises(RuntimeError, match="workspace_id is required"):
             async with get_prefect_client():
@@ -107,11 +103,7 @@ async def test_get_identity_describes_oauth_grant_without_workspace() -> None:
             "prefect_mcp_server.cloud_oauth.current_oauth_access_token",
             return_value="header.eyJtY3BfZ3JhbnRfaWQiOiAiZ3JhbnQtMSJ9.signature",
         ),
-        patch(
-            "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.enabled",
-            new_callable=PropertyMock,
-            return_value=True,
-        ),
+        patch.object(cloud_oauth.settings, "enabled", True),
         patch(
             "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.resolved_api_base_url",
             new_callable=PropertyMock,
@@ -169,11 +161,7 @@ async def test_get_identity_describes_service_account_oauth_grant_with_workspace
         patch(
             "prefect_mcp_server._prefect_client.identity.get_prefect_cloud_client"
         ) as mock_get_cloud_client,
-        patch(
-            "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.enabled",
-            new_callable=PropertyMock,
-            return_value=True,
-        ),
+        patch.object(cloud_oauth.settings, "enabled", True),
         patch(
             "prefect_mcp_server.cloud_oauth.CloudOAuthSettings.resolved_api_base_url",
             new_callable=PropertyMock,
@@ -224,11 +212,8 @@ async def test_default_server_excludes_cloud_oauth_workspace_tools() -> None:
 async def test_cloud_oauth_server_includes_oauth_workspace_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        cloud_oauth.settings,
-        "auth_token_key",
-        "notArealACCESStokenKEY",
-    )
+    monkeypatch.setattr(cloud_oauth.settings, "enabled", True)
+    monkeypatch.setattr(cloud_oauth.settings, "auth_token_key", None)
 
     server = build_cloud_mcp_server(include_docs_proxy=False)
 
@@ -244,10 +229,38 @@ async def test_cloud_oauth_server_includes_oauth_workspace_tools(
 def test_cloud_oauth_server_requires_oauth_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(cloud_oauth.settings, "enabled", False)
     monkeypatch.setattr(cloud_oauth.settings, "auth_token_key", None)
 
-    with pytest.raises(RuntimeError, match="PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY"):
+    with pytest.raises(RuntimeError, match="PREFECT_MCP_CLOUD_ENABLED=true"):
         build_cloud_mcp_server()
+
+
+def test_build_auth_provider_uses_cloud_jwks_without_runtime_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloud_oauth.settings, "enabled", True)
+    monkeypatch.setattr(cloud_oauth.settings, "auth_token_key", None)
+    monkeypatch.setattr(
+        cloud_oauth.settings, "auth_base_url", "https://api.prefect.cloud"
+    )
+    monkeypatch.setattr(
+        cloud_oauth.settings,
+        "public_base_url",
+        "https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+    )
+
+    with patch("prefect_mcp_server.cloud_oauth.JWTVerifier") as mock_verifier:
+        cloud_oauth.build_auth_provider(require_enabled=True)
+
+    mock_verifier.assert_called_once_with(
+        jwks_uri="https://api.prefect.cloud/auth/mcp/oauth/jwks.json",
+        issuer="AuthServerID",
+        audience="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+        algorithm="RS256",
+        required_scopes=["prefect-cloud:workspaces"],
+        base_url="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+    )
 
 
 def test_workspace_ref_display_name_prefers_handles() -> None:


### PR DESCRIPTION
## Summary

Now that Prefect Cloud issues MCP OAuth access tokens with RS256 keys and exposes a JWKS endpoint, the hosted Prefect Cloud MCP server should verify tokens from Cloud public keys instead of requiring Cloud token-signing secrets in the MCP runtime.

This updates hosted Cloud OAuth mode so the runtime is enabled explicitly with `PREFECT_MCP_CLOUD_ENABLED=true` and verifies bearer tokens with Cloud JWKS by default.

## Changes

- add JWKS-based token verification for hosted Cloud OAuth mode
- default hosted token verification to `RS256` and the MCP public URL as the token audience
- keep the old `PREFECT_MCP_CLOUD_AUTH_TOKEN_KEY` path as a compatibility fallback
- update Cloud OAuth docs so they no longer describe the signing key as a required runtime secret
- add a regression test proving hosted mode can build without the runtime signing secret

## Validation

- `uv run pytest tests/test_cloud_oauth.py -q`
- `uv run --all-packages --frozen pytest -q tests`
- `uv run --all-packages --frozen ty check`
- `SKIP=no-commit-to-branch uv run --all-packages pre-commit run --all-files`
- `uv run --frozen pytest -q evals --collect-only`
