### PR TITLE
Add OpenAI plugin domain verification endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Deploy your own server when you need a custom Prefect API target, self-hosted Pr
      - `PREFECT_API_URL`: `https://api.prefect.cloud/api/accounts/[ACCOUNT_ID]/workspaces/[WORKSPACE_ID]`
      - `PREFECT_API_KEY`: your Prefect Cloud API key
      - `PREFECT_API_AUTH_STRING`: basic auth credentials for self-hosted Prefect, if needed
+     - `OPENAI_APPS_CHALLENGE_TOKEN`: domain-verification token for an OpenAI public plugin submission, if needed
 
 4. Add the deployed HTTP URL to your MCP client:
 

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -12,6 +12,8 @@ from fastmcp.server.providers.proxy import ProxyClient
 from mcp.types import ToolAnnotations
 from prefect.client.base import ServerType, determine_server_type
 from pydantic import Field
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
 
 from prefect_mcp_server import _prefect_client, cloud_oauth, execution_plans
 from prefect_mcp_server.middleware import (
@@ -566,6 +568,18 @@ PRIVATE_WRITE_TOOL_ANNOTATIONS = ToolAnnotations(
 )
 
 
+async def openai_apps_challenge(_: Request) -> Response:
+    """Return the configured OpenAI public plugin domain challenge token."""
+    token = settings.openai_apps_challenge_token
+    if token is None:
+        return PlainTextResponse("", status_code=404)
+
+    return PlainTextResponse(
+        token,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 def build_prefect_mcp_server(
     *,
     name: str = "Prefect MCP Server",
@@ -576,6 +590,11 @@ def build_prefect_mcp_server(
 ) -> FastMCP:
     """Build a Prefect MCP server from shared tools and optional Cloud adapters."""
     server = FastMCP(name, auth=auth_provider)
+    server.custom_route(
+        "/.well-known/openai-apps-challenge",
+        methods=["GET"],
+        include_in_schema=False,
+    )(openai_apps_challenge)
     server.add_middleware(PrefectAuthMiddleware())
     server.add_middleware(
         FeatureFlagMiddleware(

--- a/src/prefect_mcp_server/settings.py
+++ b/src/prefect_mcp_server/settings.py
@@ -73,6 +73,11 @@ class Settings(BaseSettings):
         description="Default time window to look back for events",
     )
 
+    openai_apps_challenge_token: str | None = Field(
+        default=None,
+        description="Token returned for OpenAI public plugin domain verification",
+    )
+
     docs_mcp: DocsMcpSettings = Field(
         default_factory=DocsMcpSettings,
         description="Docs MCP proxy settings",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import pytest
 from fastmcp import FastMCP
 from fastmcp.client import Client
 from prefect.client.orchestration import PrefectClient
+from starlette.testclient import TestClient
 
 from prefect_mcp_server.server import build_prefect_mcp_server
 from prefect_mcp_server.settings import settings
@@ -59,6 +60,38 @@ async def test_all_prefect_tools_declare_submission_annotations(
         assert tool.annotations.openWorldHint is False
         assert tool.annotations.destructiveHint is False
         assert tool.annotations.readOnlyHint is (tool.name != "execution_plans_publish")
+
+
+def test_openai_apps_challenge_returns_configured_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "openai_apps_challenge_token",
+        "domain-verification-token",
+    )
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with TestClient(server.http_app()) as client:
+        response = client.get("/.well-known/openai-apps-challenge")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.text == "domain-verification-token"
+
+
+def test_openai_apps_challenge_is_unavailable_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "openai_apps_challenge_token", None)
+    server = build_prefect_mcp_server(include_docs_proxy=False)
+
+    with TestClient(server.http_app()) as client:
+        response = client.get("/.well-known/openai-apps-challenge")
+
+    assert response.status_code == 404
+    assert response.text == ""
 
 
 async def test_get_deployments_with_test_data(


### PR DESCRIPTION
## Summary

- serve `/.well-known/openai-apps-challenge` as unauthenticated plain text
- source the value from `OPENAI_APPS_CHALLENGE_TOKEN`; no verification token is committed
- return 404 when the token is not configured
- document the deployment setting and cover configured/unconfigured behavior

## Why

OpenAI requires proof of control over the MCP origin before publishing an MCP-backed plugin in the public Plugins Directory. The submitted MCP URL uses `prefect.fastmcp.app`, so the challenge must be served from that origin unless the MCP moves to a Prefect-controlled custom domain.

## Validation

- focused route tests pass
- full pre-commit suite passes
- verified the route remains anonymously accessible when MCP JWT authentication is enabled