### PR TITLE
Fix hosted Cloud OAuth issuer validation

### DIFF
--- a/src/prefect_mcp_server/cloud_oauth.py
+++ b/src/prefect_mcp_server/cloud_oauth.py
@@ -54,7 +54,7 @@ class CloudOAuthSettings(BaseSettings):
     api_base_url: str | None = Field(default=None)
     auth_base_url: str | None = Field(default=None)
     authorization_server: str | None = Field(default=None)
-    auth_issuer: str = Field(default="AuthServerID")
+    auth_issuer: str | None = Field(default=None)
     auth_audience: str | None = Field(default=None)
     auth_algorithm: str | None = Field(default=None)
     client_id: str | None = Field(default=None)
@@ -85,6 +85,14 @@ class CloudOAuthSettings(BaseSettings):
         if self.auth_jwks_uri:
             return self.auth_jwks_uri
         return f"{self.resolved_auth_base_url}/auth/mcp/oauth/jwks.json"
+
+    @property
+    def resolved_auth_issuer(self) -> str:
+        if self.auth_issuer:
+            return self.auth_issuer.rstrip("/")
+        if self.auth_token_key:
+            return "AuthServerID"
+        return self.resolved_auth_base_url
 
     @property
     def resolved_auth_audience(self) -> str:
@@ -197,7 +205,7 @@ def build_auth_provider(*, require_enabled: bool = False) -> RemoteAuthProvider 
     if settings.auth_token_key is not None:
         token_verifier = JWTVerifier(
             public_key=settings.auth_token_key,
-            issuer=settings.auth_issuer,
+            issuer=settings.resolved_auth_issuer,
             audience=settings.resolved_auth_audience,
             algorithm=settings.resolved_auth_algorithm,
             required_scopes=["prefect-cloud:workspaces"],
@@ -206,7 +214,7 @@ def build_auth_provider(*, require_enabled: bool = False) -> RemoteAuthProvider 
     else:
         token_verifier = JWTVerifier(
             jwks_uri=settings.resolved_auth_jwks_uri,
-            issuer=settings.auth_issuer,
+            issuer=settings.resolved_auth_issuer,
             audience=settings.resolved_auth_audience,
             algorithm=settings.resolved_auth_algorithm,
             required_scopes=["prefect-cloud:workspaces"],

--- a/tests/test_cloud_oauth.py
+++ b/tests/test_cloud_oauth.py
@@ -255,11 +255,33 @@ def test_build_auth_provider_uses_cloud_jwks_without_runtime_secret(
 
     mock_verifier.assert_called_once_with(
         jwks_uri="https://api.prefect.cloud/auth/mcp/oauth/jwks.json",
-        issuer="AuthServerID",
+        issuer="https://api.prefect.cloud",
         audience="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
         algorithm="RS256",
         required_scopes=["prefect-cloud:workspaces"],
         base_url="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+    )
+
+
+def test_build_auth_provider_keeps_legacy_secret_issuer_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloud_oauth.settings, "enabled", True)
+    monkeypatch.setattr(cloud_oauth.settings, "auth_token_key", "secret")
+    monkeypatch.setattr(cloud_oauth.settings, "auth_issuer", None)
+    monkeypatch.setattr(cloud_oauth.settings, "auth_audience", None)
+    monkeypatch.setattr(cloud_oauth.settings, "auth_algorithm", None)
+
+    with patch("prefect_mcp_server.cloud_oauth.JWTVerifier") as mock_verifier:
+        cloud_oauth.build_auth_provider(require_enabled=True)
+
+    mock_verifier.assert_called_once_with(
+        public_key="secret",
+        issuer="AuthServerID",
+        audience="AuthServerID",
+        algorithm="HS256",
+        required_scopes=["prefect-cloud:workspaces"],
+        base_url=cloud_oauth.settings.resolved_public_base_url,
     )
 
 


### PR DESCRIPTION
**The problem**

Prefect Cloud now issues hosted MCP OAuth tokens with `iss=https://api.prefect.cloud`. The hosted MCP server still used the old `AuthServerID` default when it verified RS256 tokens from Cloud JWKS. Claude could finish browser auth, but the MCP server rejected the token on reconnect.

**The fix**

This changes the JWKS-backed Cloud OAuth path to default the expected issuer to the configured Cloud auth base URL. The old `AuthServerID` default remains only for the legacy shared-secret path. The tests now assert both paths so this mismatch is caught.

## Rollout caveats

- watch: hosted MCP `initialize` 401s — continued 401s after deploy mean the resource server still rejects issued tokens.
- rollback: reverting restores the `AuthServerID` issuer default and breaks prod browser OAuth tokens.

<details><summary>Session context</summary>

After the Nebula release, Cloud discovery and issued tokens used `https://api.prefect.cloud` as issuer. Claude Code still received 401 on MCP reconnect. The hosted MCP resource server was validating the token with `AuthServerID`, so the Cloud fix needed this paired MCP server change.

</details>