### PR TITLE
Default Cloud OAuth audience to MCP resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Cloud OAuth settings use the `PREFECT_MCP_CLOUD_` prefix:
 | `PREFECT_MCP_CLOUD_AUTH_BASE_URL` | Optional override for auth helper endpoints |
 | `PREFECT_MCP_CLOUD_AUTH_JWKS_URI` | Optional override for the Prefect Cloud MCP OAuth JWKS endpoint |
 | `PREFECT_MCP_CLOUD_AUTHORIZATION_SERVER` | Optional override for advertised OAuth authorization server |
-| `PREFECT_MCP_CLOUD_AUTH_AUDIENCE` | Optional override for the expected token audience; defaults to the hosted MCP public URL |
+| `PREFECT_MCP_CLOUD_AUTH_AUDIENCE` | Optional override for the expected token audience; defaults to the hosted MCP resource URL (`<public base URL>/mcp`) |
 | `PREFECT_MCP_CLOUD_CLIENT_ID` | Optional service-account MCP OAuth client id for unattended token exchange |
 | `PREFECT_MCP_CLOUD_CLIENT_SECRET` | Optional service-account MCP OAuth client secret for unattended token exchange |
 | `PREFECT_MCP_CLOUD_PUBLIC_BASE_URL` | Public base URL for the hosted MCP server |

--- a/src/prefect_mcp_server/cloud_oauth.py
+++ b/src/prefect_mcp_server/cloud_oauth.py
@@ -20,6 +20,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 CloudEnvironment = Literal["local", "stg", "prod"]
+DEFAULT_MCP_PATH = "/mcp"
 
 
 def cloud_origin(environment: CloudEnvironment) -> str:
@@ -81,6 +82,13 @@ class CloudOAuthSettings(BaseSettings):
         return self.public_base_url.rstrip("/")
 
     @property
+    def resolved_resource_url(self) -> str:
+        base_url = self.resolved_public_base_url
+        if urlparse(base_url).path.rstrip("/") == DEFAULT_MCP_PATH:
+            return base_url
+        return f"{base_url}{DEFAULT_MCP_PATH}"
+
+    @property
     def resolved_auth_jwks_uri(self) -> str:
         if self.auth_jwks_uri:
             return self.auth_jwks_uri
@@ -100,7 +108,7 @@ class CloudOAuthSettings(BaseSettings):
             return self.auth_audience.rstrip("/")
         if self.auth_token_key:
             return "AuthServerID"
-        return self.resolved_public_base_url
+        return self.resolved_resource_url
 
     @property
     def resolved_auth_algorithm(self) -> str:

--- a/tests/test_cloud_oauth.py
+++ b/tests/test_cloud_oauth.py
@@ -247,7 +247,7 @@ def test_build_auth_provider_uses_cloud_jwks_without_runtime_secret(
     monkeypatch.setattr(
         cloud_oauth.settings,
         "public_base_url",
-        "https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+        "https://prefect.fastmcp.app",
     )
 
     with patch("prefect_mcp_server.cloud_oauth.JWTVerifier") as mock_verifier:
@@ -256,10 +256,37 @@ def test_build_auth_provider_uses_cloud_jwks_without_runtime_secret(
     mock_verifier.assert_called_once_with(
         jwks_uri="https://api.prefect.cloud/auth/mcp/oauth/jwks.json",
         issuer="https://api.prefect.cloud",
-        audience="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+        audience="https://prefect.fastmcp.app/mcp",
         algorithm="RS256",
         required_scopes=["prefect-cloud:workspaces"],
-        base_url="https://prefect-cloud-mcp-server.fastmcp.app/mcp",
+        base_url="https://prefect.fastmcp.app",
+    )
+
+
+def test_build_auth_provider_does_not_double_append_mcp_resource_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloud_oauth.settings, "enabled", True)
+    monkeypatch.setattr(cloud_oauth.settings, "auth_token_key", None)
+    monkeypatch.setattr(
+        cloud_oauth.settings, "auth_base_url", "https://api.prefect.cloud"
+    )
+    monkeypatch.setattr(
+        cloud_oauth.settings,
+        "public_base_url",
+        "https://prefect.fastmcp.app/mcp",
+    )
+
+    with patch("prefect_mcp_server.cloud_oauth.JWTVerifier") as mock_verifier:
+        cloud_oauth.build_auth_provider(require_enabled=True)
+
+    mock_verifier.assert_called_once_with(
+        jwks_uri="https://api.prefect.cloud/auth/mcp/oauth/jwks.json",
+        issuer="https://api.prefect.cloud",
+        audience="https://prefect.fastmcp.app/mcp",
+        algorithm="RS256",
+        required_scopes=["prefect-cloud:workspaces"],
+        base_url="https://prefect.fastmcp.app/mcp",
     )
 
 


### PR DESCRIPTION
**The problem**

Hosted Cloud OAuth binds each access token to the requested MCP resource. For the hosted server, that resource is `https://prefect.fastmcp.app/mcp`.

The MCP server defaulted the expected audience to `PREFECT_MCP_CLOUD_PUBLIC_BASE_URL`. In Horizon, that value is the bare server origin. The server rejected valid tokens unless `PREFECT_MCP_CLOUD_AUTH_AUDIENCE` was set by hand.

**The fix**

This changes the default Cloud OAuth audience to the hosted MCP resource URL. A bare public base URL now becomes `<public base URL>/mcp`.

Explicit audience overrides still win. The legacy shared-secret mode still uses `AuthServerID`, so local prototype behavior does not change.

## Rollout caveats

- no-op: deployments that set `PREFECT_MCP_CLOUD_AUTH_AUDIENCE` keep using that explicit value.
- watch: hosted MCP `initialize` 401s — continued 401s after deploy mean the verifier still rejects issued tokens.

<details><summary>Session context</summary>

Production browser OAuth succeeded, but Claude Code failed when it reconnected to `https://prefect.fastmcp.app/mcp`.
The issued token had the correct issuer, signature, and expiry.
The failure stopped after we set `PREFECT_MCP_CLOUD_AUTH_AUDIENCE=https://prefect.fastmcp.app/mcp` in Horizon.
This PR makes that manual setting unnecessary for the hosted server.

</details>
