### PR TITLE
Fix the release-notes eval rubric rejecting correct answers

### DIFF
--- a/evals/docs/test_latest_release_notes.py
+++ b/evals/docs/test_latest_release_notes.py
@@ -66,14 +66,21 @@ async def test_agent_reports_latest_prefect_release(
     await evaluate_response(
         f"""Does the response accurately summarize the authoritative latest Prefect OSS release?
 
-Expected version: {version}
-Expected release date: {released_on}
-Expected source URL: {release["html_url"]}
+Required — the response must identify these:
+- Version: {version}
+- Release date: {released_on}
+- A summary of important user-facing changes, inventing none of them
+- A link to an official Prefect docs or GitHub release-notes page
+
 Authoritative release notes:
 {release["body"]}
 
-The response must identify the exact patch version and release date, summarize
-important user-facing changes without inventing any, and link to an official
-Prefect docs or GitHub release-notes page.""",
+Judge only against the "Required" list above. The following are context for you,
+not requirements on the response — do not fail it over either one:
+- The release is titled "{release["name"]}". Stating it, abbreviating it, or
+  omitting it entirely are all acceptable; the prompt never asked for a title.
+- Any official Prefect docs or GitHub release-notes URL satisfies the link
+  requirement. A docs.prefect.io release-notes page is valid; {release["html_url"]}
+  is not the only permitted link.""",
         result.output,
     )


### PR DESCRIPTION
`test_agent_reports_latest_prefect_release` fails on `main` — reproducibly, not intermittently — because the rubric grades the agent against criteria the prompt never sets, and the judge then invents a stricter reading on top of that. Both of the things it currently fails on are correct answers.

The judge's two complaints, checked against the GitHub API and a live request:

```
"links to a non-existent documentation page (https://docs.prefect.io/v3/release-notes/oss/version-3-8)"
    -> HTTP 200. The page exists, and the rubric's own text permits "an official
       Prefect docs or GitHub release-notes page".

"adds a creative title 'To relinquish, perchance to retry' that doesn't appear in
 the official release notes"
    -> release["name"] is "3.8.1 - To relinquish, perchance to retry", and for this
       release the title appears in the body as well. The agent read it from the
       source material it was given.
```

The root cause is that the rubric hands the judge `release["body"]` and an `Expected source URL`, but never the release title — so a correct title looks fabricated — while `Expected source URL` reads as *the* required link rather than one acceptable example. This reframes the criteria as an explicit "Required" list and moves the title and the URL into a context block marked as non-requirements, so the judge stops grading on things the prompt didn't ask for.

The bar doesn't move: the agent still has to report the exact version and release date, summarize real user-facing changes without inventing any, and link to an official page.

Verified on `main`: the eval fails 2/2 before and passes 5/5 after, with the full eval suite green 2 runs running (20 passed) and the unit suite unchanged at 126 passed.

Worth noting for whoever looks at this next: CI treats eval failures as `exit 0`, so this has been red on `main` without surfacing a signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
