### PR TITLE
fix: review_rate_limits unusable in Cloud OAuth mode

### DIFF
--- a/src/prefect_mcp_server/_prefect_client/rate_limits.py
+++ b/src/prefect_mcp_server/_prefect_client/rate_limits.py
@@ -1,6 +1,7 @@
 """Rate limits inspection for Prefect Cloud."""
 
 from datetime import datetime, timedelta, timezone
+from uuid import UUID
 
 from prefect_mcp_server._prefect_client.client import (
     get_prefect_client,
@@ -37,12 +38,15 @@ DEFAULT_KEYS = [
 async def get_rate_limits(
     since: datetime | None = None,
     until: datetime | None = None,
+    workspace_id: UUID | None = None,
 ) -> RateLimitsResult:
     """Get rate limit usage for the Cloud account across all common operation groups.
 
     Args:
         since: Start time for usage data (defaults to 3 days ago)
         until: End time for usage data (defaults to 1 minute ago)
+        workspace_id: Workspace to resolve the account from (required in
+            Prefect Cloud OAuth mode)
 
     Returns:
         RateLimitsResult with grouped throttling periods showing which operation
@@ -50,7 +54,7 @@ async def get_rate_limits(
         consecutive stretch of throttling
     """
     try:
-        async with get_prefect_client() as client:
+        async with get_prefect_client(workspace_id=workspace_id) as client:
             api_url = str(client.api_url)
 
             # Extract account_id from Cloud API URL
@@ -65,7 +69,9 @@ async def get_rate_limits(
             if until is None:
                 until = datetime.now(timezone.utc) - timedelta(minutes=1)
 
-            async with get_prefect_cloud_client() as cloud_client:
+            async with get_prefect_cloud_client(
+                workspace_id=workspace_id
+            ) as cloud_client:
                 # Query all keys in one request
                 params = {
                     "since": since.isoformat(),

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -500,6 +500,7 @@ async def get_object_schema(
 
 
 async def review_rate_limits(
+    workspace_id: WorkspaceId | None = None,
     since: Annotated[
         datetime | None,
         Field(
@@ -539,7 +540,9 @@ async def review_rate_limits(
         - Check recent throttling: review_rate_limits()
         - Custom time range: review_rate_limits(since="2025-09-30T00:00:00Z", until="2025-10-01T00:00:00Z")
     """
-    return await _prefect_client.get_rate_limits(since=since, until=until)
+    return await _prefect_client.get_rate_limits(
+        since=since, until=until, workspace_id=workspace_id
+    )
 
 
 CORE_TOOLS = (

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -2,8 +2,12 @@
 
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from fastmcp import Client
 
 from prefect_mcp_server._prefect_client.rate_limits import get_rate_limits
+from prefect_mcp_server.server import build_prefect_mcp_server
 
 
 async def test_get_rate_limits_empty_response() -> None:
@@ -816,3 +820,56 @@ async def test_get_rate_limits_handles_errors() -> None:
     assert result["account_id"] is None
     assert result["summary"] is None
     assert result["throttling_periods"] is None
+
+
+async def test_get_rate_limits_passes_workspace_id_to_clients() -> None:
+    """workspace_id must reach both clients so OAuth mode can scope the request."""
+    workspace_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+    mock_client = AsyncMock()
+    mock_client.api_url = (
+        f"https://api.prefect.cloud/api/accounts/abc-123/workspaces/{workspace_id}"
+    )
+
+    mock_cloud_client = AsyncMock()
+    mock_cloud_client.get = AsyncMock(
+        return_value={
+            "account": "abc-123",
+            "since": "2025-09-30T00:00:00Z",
+            "until": "2025-10-01T00:00:00Z",
+            "minutes": [],
+            "keys": {},
+        }
+    )
+
+    with (
+        patch(
+            "prefect_mcp_server._prefect_client.rate_limits.get_prefect_client"
+        ) as mock_get_client,
+        patch(
+            "prefect_mcp_server._prefect_client.rate_limits.get_prefect_cloud_client"
+        ) as mock_get_cloud_client,
+    ):
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+        mock_get_cloud_client.return_value.__aenter__.return_value = mock_cloud_client
+        mock_get_cloud_client.return_value.__aexit__.return_value = None
+
+        result = await get_rate_limits(workspace_id=workspace_id)
+
+    assert result["success"] is True
+    mock_get_client.assert_called_once_with(workspace_id=workspace_id)
+    mock_get_cloud_client.assert_called_once_with(workspace_id=workspace_id)
+
+
+async def test_review_rate_limits_tool_accepts_workspace_id() -> None:
+    """The MCP tool schema must expose workspace_id for OAuth mode."""
+    server = build_prefect_mcp_server(
+        include_docs_proxy=False,
+        include_cloud_tools=True,
+    )
+
+    async with Client(server) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    schema = tools["review_rate_limits"].inputSchema
+    assert "workspace_id" in schema["properties"]


### PR DESCRIPTION
this PR adds a `workspace_id` parameter to `review_rate_limits` — in Cloud OAuth mode the tool errored with `workspace_id is required when using Prefect Cloud OAuth mode`, but its input schema had no `workspace_id` parameter, so it was impossible to call.

<details>
<summary>details</summary>

- threads `workspace_id` from the tool through `get_rate_limits` to both `get_prefect_client` and `get_prefect_cloud_client`
- adds regression tests: the client factories receive the `workspace_id`, and the tool's input schema exposes it
- caveat: `/accounts/{account_id}/rate-limits/usage` is an account-level path — I haven't been able to verify whether workspace-scoped OAuth tokens are authorized for it, so OAuth-mode calls may still be rejected server-side even with this fix. this at least makes the tool callable and surfaces the real answer

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)