### PR TITLE
fix: get_identity and review_rate_limits broken in Cloud OAuth mode

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -36,7 +36,7 @@ MODEL_PROVIDER=openai just evals
 SIMPLE_AGENT_MODEL=openai:gpt-4o REASONING_AGENT_MODEL=openai:gpt-4.1 just evals
 
 # override just one model
-REASONING_AGENT_MODEL=anthropic:claude-opus-4-1-20250805 just evals
+REASONING_AGENT_MODEL=anthropic:claude-opus-5 just evals
 ```
 
 Provider defaults:

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -221,9 +221,7 @@ def evaluate_response() -> Callable[[str, str], Awaitable[None]]:
         Raises:
             AssertionError: If evaluation fails, with explanation
         """
-        evaluator_model = os.getenv(
-            "EVALUATOR_MODEL", "anthropic:claude-opus-5"
-        )
+        evaluator_model = os.getenv("EVALUATOR_MODEL", "anthropic:claude-opus-5")
         evaluator = Agent(
             name="Response Evaluator",
             model=evaluator_model,

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -13,7 +13,7 @@ Environment Variables:
         - Default for anthropic: "anthropic:claude-sonnet-4-5"
         - Default for openai: "openai:gpt-4.1"
 
-    EVALUATOR_MODEL: Override default evaluator model (default: "anthropic:claude-opus-4-1-20250805")
+    EVALUATOR_MODEL: Override default evaluator model (default: "anthropic:claude-opus-5")
 """
 
 import os
@@ -222,7 +222,7 @@ def evaluate_response() -> Callable[[str, str], Awaitable[None]]:
             AssertionError: If evaluation fails, with explanation
         """
         evaluator_model = os.getenv(
-            "EVALUATOR_MODEL", "anthropic:claude-opus-4-1-20250805"
+            "EVALUATOR_MODEL", "anthropic:claude-opus-5"
         )
         evaluator = Agent(
             name="Response Evaluator",

--- a/src/prefect_mcp_server/_prefect_client/identity.py
+++ b/src/prefect_mcp_server/_prefect_client/identity.py
@@ -2,8 +2,6 @@
 
 from uuid import UUID
 
-from prefect.client.cloud import CloudUnauthorizedError
-
 from prefect_mcp_server import cloud_oauth
 from prefect_mcp_server._prefect_client.client import (
     get_prefect_client,
@@ -51,8 +49,13 @@ async def get_identity(workspace_id: UUID | None = None) -> IdentityResult:
     """Get identity and connection information for the current Prefect instance."""
     try:
         access_token = cloud_oauth.current_oauth_access_token()
-        if workspace_id is None and cloud_oauth.settings.enabled and access_token:
-            identity = await _get_cloud_oauth_identity(access_token)
+        if cloud_oauth.settings.enabled and access_token:
+            # OAuth tokens are workspace-scoped and cannot call account-level
+            # endpoints like /me/ or /accounts/{id}, so always describe the
+            # grant instead of fetching full Cloud identity.
+            identity = await _get_cloud_oauth_identity(
+                access_token, workspace_id=workspace_id
+            )
             return {
                 "success": True,
                 "identity": identity,
@@ -73,19 +76,7 @@ async def get_identity(workspace_id: UUID | None = None) -> IdentityResult:
                     workspace_id=workspace_id
                 ) as cloud_client:
                     # Get user info from /me/ endpoint
-                    try:
-                        me_data = await cloud_client.get("/me/")
-                    except CloudUnauthorizedError:
-                        if cloud_oauth.settings.enabled and access_token:
-                            identity = await _get_cloud_oauth_identity(
-                                access_token, workspace_id=workspace_id
-                            )
-                            return {
-                                "success": True,
-                                "identity": identity,
-                                "error": None,
-                            }
-                        raise
+                    me_data = await cloud_client.get("/me/")
 
                     user_info: UserInfo = {
                         "id": str(me_data.get("id")) if me_data.get("id") else None,

--- a/src/prefect_mcp_server/_prefect_client/rate_limits.py
+++ b/src/prefect_mcp_server/_prefect_client/rate_limits.py
@@ -1,6 +1,7 @@
 """Rate limits inspection for Prefect Cloud."""
 
 from datetime import datetime, timedelta, timezone
+from uuid import UUID
 
 from prefect_mcp_server._prefect_client.client import (
     get_prefect_client,
@@ -37,12 +38,15 @@ DEFAULT_KEYS = [
 async def get_rate_limits(
     since: datetime | None = None,
     until: datetime | None = None,
+    workspace_id: UUID | None = None,
 ) -> RateLimitsResult:
     """Get rate limit usage for the Cloud account across all common operation groups.
 
     Args:
         since: Start time for usage data (defaults to 3 days ago)
         until: End time for usage data (defaults to 1 minute ago)
+        workspace_id: Workspace to resolve the account from (required in
+            Prefect Cloud OAuth mode)
 
     Returns:
         RateLimitsResult with grouped throttling periods showing which operation
@@ -50,7 +54,7 @@ async def get_rate_limits(
         consecutive stretch of throttling
     """
     try:
-        async with get_prefect_client() as client:
+        async with get_prefect_client(workspace_id=workspace_id) as client:
             api_url = str(client.api_url)
 
             # Extract account_id from Cloud API URL
@@ -65,7 +69,9 @@ async def get_rate_limits(
             if until is None:
                 until = datetime.now(timezone.utc) - timedelta(minutes=1)
 
-            async with get_prefect_cloud_client() as cloud_client:
+            async with get_prefect_cloud_client(
+                workspace_id=workspace_id
+            ) as cloud_client:
                 # Query all keys in one request
                 params = {
                     "since": since.isoformat(),

--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -500,6 +500,7 @@ async def get_object_schema(
 
 
 async def review_rate_limits(
+    workspace_id: WorkspaceId | None = None,
     since: Annotated[
         datetime | None,
         Field(
@@ -539,7 +540,9 @@ async def review_rate_limits(
         - Check recent throttling: review_rate_limits()
         - Custom time range: review_rate_limits(since="2025-09-30T00:00:00Z", until="2025-10-01T00:00:00Z")
     """
-    return await _prefect_client.get_rate_limits(since=since, until=until)
+    return await _prefect_client.get_rate_limits(
+        since=since, until=until, workspace_id=workspace_id
+    )
 
 
 CORE_TOOLS = (

--- a/tests/test_cloud_oauth.py
+++ b/tests/test_cloud_oauth.py
@@ -7,7 +7,6 @@ from uuid import UUID
 import pytest
 from fastmcp import Client
 from fastmcp.server.auth.providers.jwt import JWTVerifier
-from prefect.client.cloud import CloudUnauthorizedError
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
@@ -130,24 +129,13 @@ async def test_get_identity_describes_oauth_grant_without_workspace() -> None:
     )
 
 
-async def test_get_identity_describes_service_account_oauth_grant_with_workspace() -> (
-    None
-):
+async def test_get_identity_with_workspace_never_calls_account_endpoints() -> None:
+    """OAuth tokens are workspace-scoped; account-level endpoints return 403."""
     workspace = cloud_oauth.WorkspaceRef(
         account_id=ACCOUNT_ID,
         account_handle="acme",
         workspace_id=WORKSPACE_ID,
         workspace_handle="prod",
-    )
-    mock_client = AsyncMock()
-    mock_client.api_url = (
-        f"https://api.prefect.cloud/api/accounts/{ACCOUNT_ID}/workspaces/{WORKSPACE_ID}"
-    )
-    mock_cloud_client = AsyncMock()
-    mock_cloud_client.get = AsyncMock(
-        side_effect=CloudUnauthorizedError(
-            "Only users (not service accounts) can access this endpoint."
-        )
     )
 
     with (
@@ -172,11 +160,10 @@ async def test_get_identity_describes_service_account_oauth_grant_with_workspace
             AsyncMock(return_value=[workspace]),
         ) as mock_list_authorized_workspaces,
     ):
-        mock_get_client.return_value.__aenter__.return_value = mock_client
-        mock_get_cloud_client.return_value.__aenter__.return_value = mock_cloud_client
-        mock_get_cloud_client.return_value.__aexit__.return_value = None
-
         result = await get_identity(workspace_id=WORKSPACE_ID)
+
+    mock_get_client.assert_not_called()
+    mock_get_cloud_client.assert_not_called()
 
     assert result["success"] is True
     assert result["identity"] == {

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -2,8 +2,12 @@
 
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from fastmcp import Client
 
 from prefect_mcp_server._prefect_client.rate_limits import get_rate_limits
+from prefect_mcp_server.server import build_prefect_mcp_server
 
 
 async def test_get_rate_limits_empty_response() -> None:
@@ -816,3 +820,56 @@ async def test_get_rate_limits_handles_errors() -> None:
     assert result["account_id"] is None
     assert result["summary"] is None
     assert result["throttling_periods"] is None
+
+
+async def test_get_rate_limits_passes_workspace_id_to_clients() -> None:
+    """workspace_id must reach both clients so OAuth mode can scope the request."""
+    workspace_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+    mock_client = AsyncMock()
+    mock_client.api_url = (
+        f"https://api.prefect.cloud/api/accounts/abc-123/workspaces/{workspace_id}"
+    )
+
+    mock_cloud_client = AsyncMock()
+    mock_cloud_client.get = AsyncMock(
+        return_value={
+            "account": "abc-123",
+            "since": "2025-09-30T00:00:00Z",
+            "until": "2025-10-01T00:00:00Z",
+            "minutes": [],
+            "keys": {},
+        }
+    )
+
+    with (
+        patch(
+            "prefect_mcp_server._prefect_client.rate_limits.get_prefect_client"
+        ) as mock_get_client,
+        patch(
+            "prefect_mcp_server._prefect_client.rate_limits.get_prefect_cloud_client"
+        ) as mock_get_cloud_client,
+    ):
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+        mock_get_cloud_client.return_value.__aenter__.return_value = mock_cloud_client
+        mock_get_cloud_client.return_value.__aexit__.return_value = None
+
+        result = await get_rate_limits(workspace_id=workspace_id)
+
+    assert result["success"] is True
+    mock_get_client.assert_called_once_with(workspace_id=workspace_id)
+    mock_get_cloud_client.assert_called_once_with(workspace_id=workspace_id)
+
+
+async def test_review_rate_limits_tool_accepts_workspace_id() -> None:
+    """The MCP tool schema must expose workspace_id for OAuth mode."""
+    server = build_prefect_mcp_server(
+        include_docs_proxy=False,
+        include_cloud_tools=True,
+    )
+
+    async with Client(server) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    schema = tools["review_rate_limits"].inputSchema
+    assert "workspace_id" in schema["properties"]


### PR DESCRIPTION
this PR fixes the two tools that were unusable in Cloud OAuth mode: `get_identity` 403'd on account-level endpoints, and `review_rate_limits` demanded a `workspace_id` its schema didn't expose. it also unbreaks the eval suite, whose judge model was retired from the Anthropic API on 2026-08-05.

both tool bugs were observed live against the hosted MCP server with an OAuth grant covering two workspaces. CI is fully green, evals at 20/20 (base was 19/20).

<details>
<summary>get_identity</summary>

- the OAuth short-circuit only fired when `workspace_id` was `None`, so passing one fell through to the full Cloud identity path, which calls account-level endpoints (`/me/`, `/accounts/{id}`) and failed with `403: MCP OAuth tokens require a consented workspace-scoped Cloud API path`
- now any request with an OAuth token returns the grant description (with `selected_workspace` when a `workspace_id` is given)
- removes the now-unreachable service-account `CloudUnauthorizedError` fallback

</details>

<details>
<summary>review_rate_limits</summary>

- the tool errored with `workspace_id is required when using Prefect Cloud OAuth mode`, but its input schema had no `workspace_id` parameter — a catch-22
- threads `workspace_id` from the tool through `get_rate_limits` to both client factories
- caveat: `/accounts/{account_id}/rate-limits/usage` is an account-level path — I couldn't verify whether workspace-scoped OAuth tokens are authorized for it, so Cloud may still reject it server-side; this at least makes the tool callable and surfaces the real answer

</details>

<details>
<summary>eval judge model</summary>

- `anthropic:claude-opus-4-1-20250805` was retired on 2026-08-05, so every eval that reached the judge failed with a 404 — swapped to the undated `anthropic:claude-opus-5` alias so retirement dates can't break the suite the same way again
- all 20 evals pass with the new judge (one more than base)

</details>

replaces #198 and #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)