### PR TITLE
fix: remove cross-tool routing from tool descriptions

### DIFF
--- a/src/prefect_mcp_server/server.py
+++ b/src/prefect_mcp_server/server.py
@@ -57,11 +57,10 @@ WorkspaceId = Annotated[
 
 
 def orientation() -> str:
-    """Explain which Prefect MCP tool to use for common Prefect operations.
+    """Return an overview of Prefect MCP capabilities and access boundaries.
 
-    Covers workspace inspection, failure diagnosis, documentation, release notes,
-    object schemas, and the separately gated execution-plan authoring tools.
-    Returns routing guidance only and does not access or modify Prefect data.
+    Summarizes supported inspection, documentation, schema, and optional authoring
+    capabilities. It does not access or modify Prefect data.
     """
     return """
     Default Prefect inspection tools are read-only. For ordinary mutations, use the CLI.
@@ -88,9 +87,9 @@ async def get_identity(
 async def list_authorized_workspaces() -> dict[str, object]:
     """List Prefect Cloud workspaces selected during OAuth consent.
 
-    This tool is only available when the server is running in Prefect Cloud
-    OAuth mode. Use it before calling workspace-scoped tools when the user
-    names a workspace by handle, account/workspace pair, or nickname.
+    Returns account handles, workspace handles, workspace IDs, and grant metadata
+    for the workspaces available to this connection. Only available in Prefect
+    Cloud OAuth mode.
     """
     workspaces = await cloud_oauth.list_authorized_workspaces()
     access_token = cloud_oauth.current_oauth_access_token()

--- a/tests/test_docs_proxy.py
+++ b/tests/test_docs_proxy.py
@@ -28,9 +28,9 @@ async def test_docs_proxy_tools_available(prefect_mcp_server: FastMCP) -> None:
             assert all(name.startswith("docs_") for name in docs_tools)
 
 
-def test_orientation_routes_release_note_questions() -> None:
+def test_orientation_describes_capabilities_without_cross_tool_routing() -> None:
     docstring = orientation.__doc__
     assert docstring is not None
-    assert "which Prefect MCP tool to use" in docstring
+    assert "capabilities and access boundaries" in docstring
     assert "does not access or modify Prefect data" in docstring
     assert "docs_get_release_notes" in orientation()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -65,6 +65,30 @@ async def test_all_prefect_tools_declare_submission_annotations(
         assert tool.annotations.readOnlyHint is (tool.name != "execution_plans_publish")
 
 
+async def test_tool_descriptions_do_not_route_between_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.experimental, "execution_plans_enabled", False)
+    server = build_prefect_mcp_server(
+        include_docs_proxy=False,
+        include_cloud_tools=True,
+        include_cloud_oauth_tools=True,
+    )
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+
+    for tool in tools:
+        description = tool.description or ""
+        for other_tool in tools:
+            if other_tool.name != tool.name:
+                assert other_tool.name not in description
+
+    descriptions = {tool.name: tool.description or "" for tool in tools}
+    assert "which Prefect MCP tool to use" not in descriptions["orientation"]
+    assert "workspace-scoped tools" not in descriptions["list_authorized_workspaces"]
+
+
 def test_openai_apps_challenge_returns_configured_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- rewrite the `orientation` description as a capability and access-boundary summary
- make `list_authorized_workspaces` describe only its own output and availability
- add regression coverage preventing exposed tool descriptions from naming other exposed tools

## Why

Anthropic's MCP Directory policy requires tool descriptions to contain no instructions about model behavior, other tools, or external instruction sources. The existing descriptions told the model which other Prefect tools to call. The tool implementations and the explicitly invoked `orientation` response remain unchanged; only discovery-time descriptions are made policy-compliant.

## Validation

- `just test` — 129 passed, 2 skipped
- `just lint`
- `just typecheck`
